### PR TITLE
Add `Package.resolved` to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 *.orig
 .swiftpm
 .idea
+Package.resolved


### PR DESCRIPTION
Add `Package.resolved` to .gitignore.

### Motivation:

- Normally we only want to pin to a specific version of a dependency in executable packages. Since this is a library package, we shouldn't do this.

### Modifications:

- It does [what nio does](https://github.com/apple/swift-nio/blob/178636d9996a571ce338d10730e42eea4d88f577/.gitignore#L9): ignore `Package.resolved`
