### PR TITLE
Require Swift 5.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.0
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the Swift Metrics API open source project


### PR DESCRIPTION
Most Swift server libraries require at least Swift 5.0. Since this package has not seen a single release yet, we should take the opportunity and require 5.0 from the get go.