### PR TITLE
Swiftformat: Extension ACL must be on declaration.

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -9,5 +9,7 @@
 --patternlet inline
 --stripunusedargs unnamed-only
 --ifdef no-indent
+--extensionacl on-declarations
+--disable typeSugar
 
 # rules

--- a/Sources/SystemMetrics/SystemMetrics.swift
+++ b/Sources/SystemMetrics/SystemMetrics.swift
@@ -335,8 +335,8 @@ public enum SystemMetrics {
     }
 }
 
-private extension Array where Element == String {
-    subscript(safe index: Int) -> String {
+extension Array where Element == String {
+    fileprivate subscript(safe index: Int) -> String {
         guard index >= 0, index < endIndex else {
             return ""
         }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,7 +26,7 @@ RUN echo 'export PATH="$HOME/.tools:$PATH"' >> $HOME/.profile
 
 # swiftformat (until part of the toolchain)
 
-ARG swiftformat_version=0.44.6
+ARG swiftformat_version=0.47.4
 RUN git clone --branch $swiftformat_version --depth 1 https://github.com/nicklockwood/SwiftFormat $HOME/.tools/swift-format
 RUN cd $HOME/.tools/swift-format && swift build -c release
 RUN ln -s $HOME/.tools/swift-format/.build/release/swiftformat $HOME/.tools/swiftformat


### PR DESCRIPTION
We nearly ran into a situation here:
https://github.com/apple/swift-metrics-extras/pull/6#discussion_r582953583

For this reason we disable the default swiftformat rule here.

Further we disable typeSugar because of: https://github.com/nicklockwood/SwiftFormat/issues/636