### PR TITLE
Add MetricsTestUtils target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,6 +19,7 @@ let package = Package(
     name: "swift-metrics-extras",
     products: [
         .library(name: "SystemMetrics", targets: ["SystemMetrics"]),
+        .library(name: "MetricsTestUtils", targets: ["MetricsTestUtils"]),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-metrics.git", from: "2.1.1"),
@@ -27,6 +28,10 @@ let package = Package(
         .target(
             name: "SystemMetrics",
             dependencies: ["CoreMetrics"]
+        ),
+        .target(
+            name: "MetricsTestUtils",
+            dependencies: ["Metrics", "CoreMetrics"]
         ),
         .testTarget(
             name: "SystemMetricsTests",

--- a/Sources/MetricsTestUtils/TestMetrics.swift
+++ b/Sources/MetricsTestUtils/TestMetrics.swift
@@ -57,7 +57,7 @@ public final class TestMetrics: MetricsFactory {
     }
 
     public func makeCounter(label: String, dimensions: [(String, String)]) -> CounterHandler {
-        self.make(label: label, dimensions: dimensions, registry: &self.counters, maker: TestCounter.init)
+        return self.make(label: label, dimensions: dimensions, registry: &self.counters, maker: TestCounter.init)
     }
 
     public func makeRecorder(label: String, dimensions: [(String, String)], aggregate: Bool) -> RecorderHandler {
@@ -68,11 +68,11 @@ public final class TestMetrics: MetricsFactory {
     }
 
     public func makeTimer(label: String, dimensions: [(String, String)]) -> TimerHandler {
-        self.make(label: label, dimensions: dimensions, registry: &self.timers, maker: TestTimer.init)
+        return self.make(label: label, dimensions: dimensions, registry: &self.timers, maker: TestTimer.init)
     }
 
     private func make<Item>(label: String, dimensions: [(String, String)], registry: inout [FullKey: Item], maker: (String, [(String, String)]) -> Item) -> Item {
-        self.lock.withLock {
+        return self.lock.withLock { () -> Item in
             let item = maker(label, dimensions)
             registry[.init(label: label, dimensions: dimensions)] = item
             return item
@@ -107,8 +107,8 @@ extension TestMetrics.FullKey: Hashable {
         }
     }
 
-    public static func == (lhs: Self, rhs: Self) -> Bool {
-        lhs.label == rhs.label &&
+    public static func == (lhs: TestMetrics.FullKey, rhs: TestMetrics.FullKey) -> Bool {
+        return lhs.label == rhs.label &&
             Dictionary(uniqueKeysWithValues: lhs.dimensions) == Dictionary(uniqueKeysWithValues: rhs.dimensions)
     }
 }
@@ -149,11 +149,11 @@ extension TestMetrics {
     // MARK: Gauge
 
     public func expectGauge(_ metric: Gauge) throws -> TestRecorder {
-        try self.expectRecorder(metric)
+        return try self.expectRecorder(metric)
     }
 
     public func expectGauge(_ label: String, _ dimensions: [(String, String)] = []) throws -> TestRecorder {
-        try self.expectRecorder(label, dimensions)
+        return try self.expectRecorder(label, dimensions)
     }
 
     // ==== ------------------------------------------------------------------------------------------------------------
@@ -220,7 +220,7 @@ public final class TestCounter: TestMetric, CounterHandler, Equatable {
     public let dimensions: [(String, String)]
 
     public var key: TestMetrics.FullKey {
-        .init(label: self.label, dimensions: self.dimensions)
+        return TestMetrics.FullKey(label: self.label, dimensions: self.dimensions)
     }
 
     let lock = NSLock()
@@ -239,31 +239,31 @@ public final class TestCounter: TestMetric, CounterHandler, Equatable {
     }
 
     public func reset() {
-        self.lock.withLock {
+        return self.lock.withLock {
             self.values = []
         }
     }
 
     public var lastValue: Int64? {
-        self.lock.withLock {
-            values.last?.1
+        return self.lock.withLock {
+            return values.last?.1
         }
     }
 
     public var totalValue: Int64 {
-        self.lock.withLock {
-            values.map { $0.1 }.reduce(0, +)
+        return self.lock.withLock {
+            return values.map { $0.1 }.reduce(0, +)
         }
     }
 
     public var last: (Date, Int64)? {
-        self.lock.withLock {
+        return self.lock.withLock {
             values.last
         }
     }
 
     public static func == (lhs: TestCounter, rhs: TestCounter) -> Bool {
-        lhs.id == rhs.id
+        return lhs.id == rhs.id
     }
 }
 
@@ -274,7 +274,7 @@ public final class TestRecorder: TestMetric, RecorderHandler, Equatable {
     public let aggregate: Bool
 
     public var key: TestMetrics.FullKey {
-        .init(label: self.label, dimensions: self.dimensions)
+        return TestMetrics.FullKey(label: self.label, dimensions: self.dimensions)
     }
 
     let lock = NSLock()
@@ -299,19 +299,19 @@ public final class TestRecorder: TestMetric, RecorderHandler, Equatable {
     }
 
     public var lastValue: Double? {
-        self.lock.withLock {
+        return self.lock.withLock {
             values.last?.1
         }
     }
 
     public var last: (Date, Double)? {
-        self.lock.withLock {
+        return self.lock.withLock {
             values.last
         }
     }
 
     public static func == (lhs: TestRecorder, rhs: TestRecorder) -> Bool {
-        lhs.id == rhs.id
+        return lhs.id == rhs.id
     }
 }
 
@@ -322,7 +322,7 @@ public final class TestTimer: TestMetric, TimerHandler, Equatable {
     public let dimensions: [(String, String)]
 
     public var key: TestMetrics.FullKey {
-        .init(label: self.label, dimensions: self.dimensions)
+        return TestMetrics.FullKey(label: self.label, dimensions: self.dimensions)
     }
 
     let lock = NSLock()
@@ -342,7 +342,7 @@ public final class TestTimer: TestMetric, TimerHandler, Equatable {
     }
 
     func retrieveValueInPreferredUnit(atIndex i: Int) -> Double {
-        self.lock.withLock {
+        return self.lock.withLock {
             let value = _values[i].1
             guard let displayUnit = self.displayUnit else {
                 return Double(value)
@@ -358,25 +358,25 @@ public final class TestTimer: TestMetric, TimerHandler, Equatable {
     }
 
     public var lastValue: Int64? {
-        self.lock.withLock {
-            _values.last?.1
+        return self.lock.withLock {
+            return _values.last?.1
         }
     }
 
     public var values: [Int64] {
-        self.lock.withLock {
-            _values.map { $0.1 }
+        return self.lock.withLock {
+            return _values.map { $0.1 }
         }
     }
 
     public var last: (Date, Int64)? {
-        self.lock.withLock {
-            _values.last
+        return self.lock.withLock {
+            return _values.last
         }
     }
 
     public static func == (lhs: TestTimer, rhs: TestTimer) -> Bool {
-        lhs.id == rhs.id
+        return lhs.id == rhs.id
     }
 }
 

--- a/Sources/MetricsTestUtils/TestMetrics.swift
+++ b/Sources/MetricsTestUtils/TestMetrics.swift
@@ -182,7 +182,7 @@ extension TestMetrics {
 
     // MARK: Timer
 
-    public func expectTimer(_ metric: Timer) throws -> TestTimer {
+    public func expectTimer(_ metric: CoreMetrics.Timer) throws -> TestTimer {
         guard let timer = metric.handler as? TestTimer else {
             throw TestMetricsError.illegalMetricType(metric: metric.handler, expected: "\(TestTimer.self)")
         }

--- a/Sources/MetricsTestUtils/TestMetrics.swift
+++ b/Sources/MetricsTestUtils/TestMetrics.swift
@@ -1,0 +1,391 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Cluster Membership open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift Cluster Membership project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.md for the list of Swift Cluster Membership project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Cluster Membership open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift Cluster Membership project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.md for the list of Swift Cluster Membership project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Metrics API open source project
+//
+// Copyright (c) 2018-2019 Apple Inc. and the Swift Metrics API project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Metrics API project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@testable import CoreMetrics
+@testable import Metrics
+import XCTest
+
+/// Taken directly from `swift-cluster-memberships`'s own test target package, which
+/// adopts the `TestMetrics` from `swift-metrics`.
+///
+/// Metrics factory which allows inspecting recorded metrics programmatically.
+/// Only intended for tests of the Metrics API itself.
+public final class TestMetrics: MetricsFactory {
+    private let lock = NSLock()
+
+    public typealias Label = String
+    public typealias Dimensions = String
+
+    public struct FullKey {
+        let label: Label
+        let dimensions: [(String, String)]
+    }
+
+    private var counters = [FullKey: CounterHandler]()
+    private var recorders = [FullKey: RecorderHandler]()
+    private var timers = [FullKey: TimerHandler]()
+
+    public init() {
+        // nothing to do
+    }
+
+    public func makeCounter(label: String, dimensions: [(String, String)]) -> CounterHandler {
+        self.make(label: label, dimensions: dimensions, registry: &self.counters, maker: TestCounter.init)
+    }
+
+    public func makeRecorder(label: String, dimensions: [(String, String)], aggregate: Bool) -> RecorderHandler {
+        let maker = { (label: String, dimensions: [(String, String)]) -> RecorderHandler in
+            TestRecorder(label: label, dimensions: dimensions, aggregate: aggregate)
+        }
+        return self.make(label: label, dimensions: dimensions, registry: &self.recorders, maker: maker)
+    }
+
+    public func makeTimer(label: String, dimensions: [(String, String)]) -> TimerHandler {
+        self.make(label: label, dimensions: dimensions, registry: &self.timers, maker: TestTimer.init)
+    }
+
+    private func make<Item>(label: String, dimensions: [(String, String)], registry: inout [FullKey: Item], maker: (String, [(String, String)]) -> Item) -> Item {
+        self.lock.withLock {
+            let item = maker(label, dimensions)
+            registry[.init(label: label, dimensions: dimensions)] = item
+            return item
+        }
+    }
+
+    public func destroyCounter(_ handler: CounterHandler) {
+        if let testCounter = handler as? TestCounter {
+            self.counters.removeValue(forKey: testCounter.key)
+        }
+    }
+
+    public func destroyRecorder(_ handler: RecorderHandler) {
+        if let testRecorder = handler as? TestRecorder {
+            self.recorders.removeValue(forKey: testRecorder.key)
+        }
+    }
+
+    public func destroyTimer(_ handler: TimerHandler) {
+        if let testTimer = handler as? TestTimer {
+            self.timers.removeValue(forKey: testTimer.key)
+        }
+    }
+}
+
+extension TestMetrics.FullKey: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        self.label.hash(into: &hasher)
+        self.dimensions.forEach { dim in
+            dim.0.hash(into: &hasher)
+            dim.1.hash(into: &hasher)
+        }
+    }
+
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.label == rhs.label &&
+            Dictionary(uniqueKeysWithValues: lhs.dimensions) == Dictionary(uniqueKeysWithValues: rhs.dimensions)
+    }
+}
+
+// ==== ----------------------------------------------------------------------------------------------------------------
+// MARK: Assertions
+extension TestMetrics {
+    // ==== ------------------------------------------------------------------------------------------------------------
+    // MARK: Counter
+    public func expectCounter(_ metric: Counter) throws -> TestCounter {
+        metric.handler as! TestCounter
+    }
+
+    public func expectCounter(_ label: String, _ dimensions: [(String, String)] = []) throws -> TestCounter {
+        let counter: CounterHandler
+        if let c: CounterHandler = self.counters[.init(label: label, dimensions: dimensions)] {
+            counter = c
+        } else {
+            throw TestMetricsError.missingMetric(label: label, dimensions: [])
+        }
+
+        guard let testCounter = counter as? TestCounter else {
+            throw TestMetricsError.illegalMetricType(metric: counter, expected: "\(TestCounter.self)")
+        }
+
+        return testCounter
+    }
+
+    // ==== ------------------------------------------------------------------------------------------------------------
+    // MARK: Gauge
+    public func expectGauge(_ metric: Gauge) throws -> TestRecorder {
+        try self.expectRecorder(metric)
+    }
+
+    public func expectGauge(_ label: String, _ dimensions: [(String, String)] = []) throws -> TestRecorder {
+        try self.expectRecorder(label, dimensions)
+    }
+
+    // ==== ------------------------------------------------------------------------------------------------------------
+    // MARK: Recorder
+    public func expectRecorder(_ metric: Recorder) throws -> TestRecorder {
+        metric.handler as! TestRecorder
+    }
+
+    public func expectRecorder(_ label: String, _ dimensions: [(String, String)] = []) throws -> TestRecorder {
+        guard let counter = self.recorders[.init(label: label, dimensions: dimensions)] else {
+            throw TestMetricsError.missingMetric(label: label, dimensions: [])
+        }
+        guard let testRecorder = counter as? TestRecorder else {
+            throw TestMetricsError.illegalMetricType(metric: counter, expected: "\(TestRecorder.self)")
+        }
+
+        return testRecorder
+    }
+
+    // ==== ------------------------------------------------------------------------------------------------------------
+    // MARK: Timer
+    public func expectTimer(_ metric: Timer) throws -> TestTimer {
+        metric.handler as! TestTimer
+    }
+
+    public func expectTimer(_ label: String, _ dimensions: [(String, String)] = []) throws -> TestTimer {
+        guard let counter = self.timers[.init(label: label, dimensions: dimensions)] else {
+            throw TestMetricsError.missingMetric(label: label, dimensions: [])
+        }
+        guard let testTimer = counter as? TestTimer else {
+            throw TestMetricsError.illegalMetricType(metric: counter, expected: "\(TestTimer.self)")
+        }
+
+        return testTimer
+    }
+}
+
+// ==== ----------------------------------------------------------------------------------------------------------------
+// MARK: Metric type implementations
+public protocol TestMetric {
+    associatedtype Value
+
+    var key: TestMetrics.FullKey { get }
+
+    var lastValue: Value? { get }
+    var last: (Date, Value)? { get }
+}
+
+public final class TestCounter: TestMetric, CounterHandler, Equatable {
+    public let id: String
+    public let label: String
+    public let dimensions: [(String, String)]
+
+    public var key: TestMetrics.FullKey {
+        .init(label: self.label, dimensions: self.dimensions)
+    }
+
+    let lock = NSLock()
+    private var values = [(Date, Int64)]()
+
+    init(label: String, dimensions: [(String, String)]) {
+        self.id = NSUUID().uuidString
+        self.label = label
+        self.dimensions = dimensions
+    }
+
+    public func increment(by amount: Int64) {
+        self.lock.withLock {
+            self.values.append((Date(), amount))
+        }
+        print("adding \(amount) to \(self.label)\(self.dimensions.map { "\($0):\($1)" })")
+    }
+
+    public func reset() {
+        self.lock.withLock {
+            self.values = []
+        }
+        print("resetting \(self.label)")
+    }
+
+    public var lastValue: Int64? {
+        self.lock.withLock {
+            values.last?.1
+        }
+    }
+
+    public var totalValue: Int64 {
+        self.lock.withLock {
+            values.map { $0.1 }.reduce(0, +)
+        }
+    }
+
+    public var last: (Date, Int64)? {
+        self.lock.withLock {
+            values.last
+        }
+    }
+
+    public static func == (lhs: TestCounter, rhs: TestCounter) -> Bool {
+        lhs.id == rhs.id
+    }
+}
+
+public final class TestRecorder: TestMetric, RecorderHandler, Equatable {
+    public let id: String
+    public let label: String
+    public let dimensions: [(String, String)]
+    public let aggregate: Bool
+
+    public var key: TestMetrics.FullKey {
+        .init(label: self.label, dimensions: self.dimensions)
+    }
+
+    let lock = NSLock()
+    private var values = [(Date, Double)]()
+
+    init(label: String, dimensions: [(String, String)], aggregate: Bool) {
+        self.id = NSUUID().uuidString
+        self.label = label
+        self.dimensions = dimensions
+        self.aggregate = aggregate
+    }
+
+    public func record(_ value: Int64) {
+        self.record(Double(value))
+    }
+
+    public func record(_ value: Double) {
+        self.lock.withLock {
+            // this may loose precision but good enough as an example
+            values.append((Date(), Double(value)))
+        }
+        print("recording \(value) in \(self.label)\(self.dimensions.map { "\($0):\($1)" })")
+    }
+
+    public var lastValue: Double? {
+        self.lock.withLock {
+            values.last?.1
+        }
+    }
+
+    public var last: (Date, Double)? {
+        self.lock.withLock {
+            values.last
+        }
+    }
+
+    public static func == (lhs: TestRecorder, rhs: TestRecorder) -> Bool {
+        lhs.id == rhs.id
+    }
+}
+
+public final class TestTimer: TestMetric, TimerHandler, Equatable {
+    public let id: String
+    public let label: String
+    public var displayUnit: TimeUnit?
+    public let dimensions: [(String, String)]
+
+    public var key: TestMetrics.FullKey {
+        .init(label: self.label, dimensions: self.dimensions)
+    }
+
+    let lock = NSLock()
+    private var _values = [(Date, Int64)]()
+
+    init(label: String, dimensions: [(String, String)]) {
+        self.id = NSUUID().uuidString
+        self.label = label
+        self.displayUnit = nil
+        self.dimensions = dimensions
+    }
+
+    public func preferDisplayUnit(_ unit: TimeUnit) {
+        self.lock.withLock {
+            self.displayUnit = unit
+        }
+    }
+
+    func retrieveValueInPreferredUnit(atIndex i: Int) -> Double {
+        self.lock.withLock {
+            let value = _values[i].1
+            guard let displayUnit = self.displayUnit else {
+                return Double(value)
+            }
+            return Double(value) / Double(displayUnit.scaleFromNanoseconds)
+        }
+    }
+
+    public func recordNanoseconds(_ duration: Int64) {
+        self.lock.withLock {
+            _values.append((Date(), duration))
+        }
+        print("recording \(duration) in \(self.label)\(self.dimensions.map { "\($0):\($1)" })")
+    }
+
+    public var lastValue: Int64? {
+        self.lock.withLock {
+            _values.last?.1
+        }
+    }
+
+    public var values: [Int64] {
+        self.lock.withLock {
+            _values.map { $0.1 }
+        }
+    }
+
+    public var last: (Date, Int64)? {
+        self.lock.withLock {
+            _values.last
+        }
+    }
+
+    public static func == (lhs: TestTimer, rhs: TestTimer) -> Bool {
+        lhs.id == rhs.id
+    }
+}
+
+private extension NSLock {
+    func withLock<T>(_ body: () -> T) -> T {
+        self.lock()
+        defer {
+            self.unlock()
+        }
+        return body()
+    }
+}
+
+// ==== ----------------------------------------------------------------------------------------------------------------
+// MARK: Errors
+public enum TestMetricsError: Error {
+    case missingMetric(label: String, dimensions: [(String, String)])
+    case illegalMetricType(metric: Any, expected: String)
+}

--- a/Sources/MetricsTestUtils/TestMetrics.swift
+++ b/Sources/MetricsTestUtils/TestMetrics.swift
@@ -36,7 +36,7 @@ import XCTest
 /// Only intended for tests of the Metrics API itself.
 ///
 /// Created Handlers will store Metrics until they are explicitly destroyed.
-/// 
+///
 public final class TestMetrics: MetricsFactory {
     private let lock = NSLock()
 
@@ -114,10 +114,14 @@ extension TestMetrics.FullKey: Hashable {
 }
 
 // ==== ----------------------------------------------------------------------------------------------------------------
+
 // MARK: Assertions
+
 extension TestMetrics {
     // ==== ------------------------------------------------------------------------------------------------------------
+
     // MARK: Counter
+
     public func expectCounter(_ metric: Counter) throws -> TestCounter {
         guard let counter = metric.handler as? TestCounter else {
             throw TestMetricsError.illegalMetricType(metric: metric.handler, expected: "\(TestCounter.self)")
@@ -141,7 +145,9 @@ extension TestMetrics {
     }
 
     // ==== ------------------------------------------------------------------------------------------------------------
+
     // MARK: Gauge
+
     public func expectGauge(_ metric: Gauge) throws -> TestRecorder {
         try self.expectRecorder(metric)
     }
@@ -151,7 +157,9 @@ extension TestMetrics {
     }
 
     // ==== ------------------------------------------------------------------------------------------------------------
+
     // MARK: Recorder
+
     public func expectRecorder(_ metric: Recorder) throws -> TestRecorder {
         guard let recorder = metric.handler as? TestRecorder else {
             throw TestMetricsError.illegalMetricType(metric: metric.handler, expected: "\(TestRecorder.self)")
@@ -171,7 +179,9 @@ extension TestMetrics {
     }
 
     // ==== ------------------------------------------------------------------------------------------------------------
+
     // MARK: Timer
+
     public func expectTimer(_ metric: Timer) throws -> TestTimer {
         guard let timer = metric.handler as? TestTimer else {
             throw TestMetricsError.illegalMetricType(metric: metric.handler, expected: "\(TestTimer.self)")
@@ -192,7 +202,9 @@ extension TestMetrics {
 }
 
 // ==== ----------------------------------------------------------------------------------------------------------------
+
 // MARK: Metric type implementations
+
 public protocol TestMetric {
     associatedtype Value
 
@@ -368,8 +380,8 @@ public final class TestTimer: TestMetric, TimerHandler, Equatable {
     }
 }
 
-private extension NSLock {
-    func withLock<T>(_ body: () -> T) -> T {
+extension NSLock {
+    fileprivate func withLock<T>(_ body: () -> T) -> T {
         self.lock()
         defer {
             self.unlock()
@@ -379,7 +391,9 @@ private extension NSLock {
 }
 
 // ==== ----------------------------------------------------------------------------------------------------------------
+
 // MARK: Errors
+
 public enum TestMetricsError: Error {
     case missingMetric(label: String, dimensions: [(String, String)])
     case illegalMetricType(metric: Any, expected: String)

--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -32,7 +32,7 @@ here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 function replace_acceptable_years() {
     # this needs to replace all acceptable forms with 'YEARS'
-    sed -e 's/2018-2019/YEARS/' -e 's/2019/YEARS/' -e 's/2018-2020/YEARS/'
+    sed -e 's/2018-2019/YEARS/' -e 's/2019/YEARS/' -e 's/2018-2020/YEARS/' -e 's/2021/YEARS/'
 }
 
 printf "=> Checking linux tests... "


### PR DESCRIPTION
`swift-metrics-extras` looks like the perfect location to make the `TestMetrics` class public, so that we don't need to copy it around.

### Open ends:

- Right now this is just a copy and paste from: https://github.com/apple/swift-cluster-membership/blob/main/Tests/SWIMTestKit/TestMetrics.swift
- I have some questions about some functions, but let's address those inline