### PR TITLE
Update CI and fix jazzy

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,8 +17,10 @@ RUN apt-get update && apt-get install -y wget
 RUN apt-get update && apt-get install -y lsof dnsutils netcat-openbsd net-tools curl jq # used by integration tests
 
 # ruby and jazzy for docs generation
-RUN apt-get update && apt-get install -y ruby ruby-dev libsqlite3-dev
-RUN gem install jazzy --no-ri --no-rdoc
+RUN apt-get update && apt-get install -y ruby ruby-dev libsqlite3-dev build-essential
+# jazzy no longer works on xenial as ruby is too old.
+RUN if [ "${ubuntu_version}" = "focal" ] ; then echo "gem: --no-document" > ~/.gemrc; fi
+RUN if [ "${ubuntu_version}" = "focal" ] ; then gem install jazzy; fi
 
 # tools
 RUN mkdir -p $HOME/.tools

--- a/docker/docker-compose.2004.54.yaml
+++ b/docker/docker-compose.2004.54.yaml
@@ -1,0 +1,18 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: swift-metrics:20.04-5.4
+    build:
+      args:
+        ubuntu_version: "focal"
+        swift_version: "5.4"
+
+  test:
+    image: swift-metrics:20.04-5.4
+    environment: []
+      #- SANITIZER_ARG=--sanitize=thread
+
+  shell:
+    image: swift-metrics:20.04-5.4

--- a/docker/docker-compose.2004.55.yaml
+++ b/docker/docker-compose.2004.55.yaml
@@ -1,0 +1,18 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: swift-metrics:20.04-5.5
+    build:
+      args:
+        ubuntu_version: "focal"
+        swift_version: "5.5"
+
+  test:
+    image: swift-metrics:20.04-5.5
+    environment: []
+      #- SANITIZER_ARG=--sanitize=thread
+
+  shell:
+    image: swift-metrics:20.04-5.5

--- a/docker/docker-compose.2004.main.yaml
+++ b/docker/docker-compose.2004.main.yaml
@@ -1,0 +1,18 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: swift-metrics:20.04-main
+    build:
+      args:
+        base_image: "swiftlang/swift:nightly-main-focal"
+
+
+  test:
+    image: swift-metrics:20.04-main
+    environment: []
+      #- SANITIZER_ARG=--sanitize=thread
+
+  shell:
+    image: swift-metrics:20.04-main


### PR DESCRIPTION
Jazzy only works on ubuntu focal. We are missing CI for Swift 5.4+.

### Modifications:

- Add CI jobs for 5.4, 5.5 and main 
- Only run Jazzy on ubuntu focal

### Result:

CI should work again
