### PR TITLE
Update swift-metrics SPI usage

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         .library(name: "MetricsTestUtils", targets: ["MetricsTestUtils"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-metrics.git", from: "2.1.1"),
+        .package(url: "https://github.com/apple/swift-metrics.git", from: "2.3.2"),
     ],
     targets: [
         .target(

--- a/Sources/MetricsTestUtils/TestMetrics.swift
+++ b/Sources/MetricsTestUtils/TestMetrics.swift
@@ -149,8 +149,8 @@ extension TestMetrics {
     // MARK: Counter
 
     public func expectCounter(_ metric: Counter) throws -> TestCounter {
-        guard let counter = metric.handler as? TestCounter else {
-            throw TestMetricsError.illegalMetricType(metric: metric.handler, expected: "\(TestCounter.self)")
+        guard let counter = metric._handler as? TestCounter else {
+            throw TestMetricsError.illegalMetricType(metric: metric._handler, expected: "\(TestCounter.self)")
         }
         return counter
     }
@@ -185,8 +185,8 @@ extension TestMetrics {
     // MARK: Recorder
 
     public func expectRecorder(_ metric: Recorder) throws -> TestRecorder {
-        guard let recorder = metric.handler as? TestRecorder else {
-            throw TestMetricsError.illegalMetricType(metric: metric.handler, expected: "\(TestRecorder.self)")
+        guard let recorder = metric._handler as? TestRecorder else {
+            throw TestMetricsError.illegalMetricType(metric: metric._handler, expected: "\(TestRecorder.self)")
         }
         return recorder
     }
@@ -209,8 +209,8 @@ extension TestMetrics {
     // MARK: Timer
 
     public func expectTimer(_ metric: CoreMetrics.Timer) throws -> TestTimer {
-        guard let timer = metric.handler as? TestTimer else {
-            throw TestMetricsError.illegalMetricType(metric: metric.handler, expected: "\(TestTimer.self)")
+        guard let timer = metric._handler as? TestTimer else {
+            throw TestMetricsError.illegalMetricType(metric: metric._handler, expected: "\(TestTimer.self)")
         }
         return timer
     }


### PR DESCRIPTION
Because of https://github.com/apple/swift-metrics/commit/53be78637ecd165d1ddedc4e20de69b8f43ec3b7

These projects are part of the same swift-metrics umbrella and are allowed to reach for this SPI, though it was not stable and it changed now.


cc @fabianfett 