### PR TITLE
Add support for custom dimensions attached to recorded system metrics

### DIFF
--- a/Tests/SystemMetricsTests/SystemMetricsTests+XCTest.swift
+++ b/Tests/SystemMetricsTests/SystemMetricsTests+XCTest.swift
@@ -26,6 +26,8 @@ extension SystemMetricsTest {
     static var allTests: [(String, (SystemMetricsTest) -> () throws -> Void)] {
         return [
             ("testSystemMetricsGeneration", testSystemMetricsGeneration),
+            ("testSystemMetricsLabels", testSystemMetricsLabels),
+            ("testSystemMetricsConfiguration", testSystemMetricsConfiguration),
         ]
     }
 }

--- a/Tests/SystemMetricsTests/SystemMetricsTests.swift
+++ b/Tests/SystemMetricsTests/SystemMetricsTests.swift
@@ -49,9 +49,9 @@ class SystemMetricsTest: XCTestCase {
     func testSystemMetricsConfiguration() throws {
         let labels = SystemMetrics.Labels(prefix: "pfx_", virtualMemoryBytes: "vmb", residentMemoryBytes: "rmb", startTimeSeconds: "sts", cpuSecondsTotal: "cpt", maxFds: "mfd", openFds: "ofd")
         let dimensions = [("app", "example"), ("environment", "production")]
-        let configuration = SystemMetrics.Configuration(pollInterval: .microseconds(123456789), labels: labels, dimensions: dimensions)
+        let configuration = SystemMetrics.Configuration(pollInterval: .microseconds(123_456_789), labels: labels, dimensions: dimensions)
 
-        XCTAssertTrue(configuration.interval == .microseconds(123456789))
+        XCTAssertTrue(configuration.interval == .microseconds(123_456_789))
 
         XCTAssertNotNil(configuration.dataProvider)
 

--- a/Tests/SystemMetricsTests/SystemMetricsTests.swift
+++ b/Tests/SystemMetricsTests/SystemMetricsTests.swift
@@ -51,7 +51,7 @@ class SystemMetricsTest: XCTestCase {
         let dimensions = [("app", "example"), ("environment", "production")]
         let configuration = SystemMetrics.Configuration(pollInterval: .microseconds(123456789), labels: labels, dimensions: dimensions)
 
-        XCTAssertEqual(configuration.interval, .microseconds(123456789))
+        XCTAssertTrue(configuration.interval == .microseconds(123456789))
 
         XCTAssertNotNil(configuration.dataProvider)
 

--- a/Tests/SystemMetricsTests/SystemMetricsTests.swift
+++ b/Tests/SystemMetricsTests/SystemMetricsTests.swift
@@ -34,4 +34,38 @@ class SystemMetricsTest: XCTestCase {
         XCTAssertNotNil(metrics.maxFileDescriptors)
         XCTAssertNotNil(metrics.openFileDescriptors)
     }
+
+    func testSystemMetricsLabels() throws {
+        let labels = SystemMetrics.Labels(prefix: "pfx+", virtualMemoryBytes: "vmb", residentMemoryBytes: "rmb", startTimeSeconds: "sts", cpuSecondsTotal: "cpt", maxFds: "mfd", openFds: "ofd")
+
+        XCTAssertEqual(labels.label(for: \.virtualMemoryBytes), "pfx+vmb")
+        XCTAssertEqual(labels.label(for: \.residentMemoryBytes), "pfx+rmb")
+        XCTAssertEqual(labels.label(for: \.startTimeSeconds), "pfx+sts")
+        XCTAssertEqual(labels.label(for: \.cpuSecondsTotal), "pfx+cpt")
+        XCTAssertEqual(labels.label(for: \.maxFileDescriptors), "pfx+mfd")
+        XCTAssertEqual(labels.label(for: \.openFileDescriptors), "pfx+ofd")
+    }
+
+    func testSystemMetricsConfiguration() throws {
+        let labels = SystemMetrics.Labels(prefix: "pfx_", virtualMemoryBytes: "vmb", residentMemoryBytes: "rmb", startTimeSeconds: "sts", cpuSecondsTotal: "cpt", maxFds: "mfd", openFds: "ofd")
+        let dimensions = [("app", "example"), ("environment", "production")]
+        let configuration = SystemMetrics.Configuration(pollInterval: .microseconds(123456789), labels: labels, dimensions: dimensions)
+
+        XCTAssertEqual(configuration.interval, .microseconds(123456789))
+
+        XCTAssertNotNil(configuration.dataProvider)
+
+        XCTAssertEqual(configuration.labels.label(for: \.virtualMemoryBytes), "pfx_vmb")
+        XCTAssertEqual(configuration.labels.label(for: \.residentMemoryBytes), "pfx_rmb")
+        XCTAssertEqual(configuration.labels.label(for: \.startTimeSeconds), "pfx_sts")
+        XCTAssertEqual(configuration.labels.label(for: \.cpuSecondsTotal), "pfx_cpt")
+        XCTAssertEqual(configuration.labels.label(for: \.maxFileDescriptors), "pfx_mfd")
+        XCTAssertEqual(configuration.labels.label(for: \.openFileDescriptors), "pfx_ofd")
+
+        XCTAssertTrue(configuration.dimensions.contains(where: { $0 == ("app", "example") }))
+        XCTAssertTrue(configuration.dimensions.contains(where: { $0 == ("environment", "production") }))
+
+        XCTAssertFalse(configuration.dimensions.contains(where: { $0 == ("environment", "staging") }))
+        XCTAssertFalse(configuration.dimensions.contains(where: { $0 == ("process", "example") }))
+    }
 }


### PR DESCRIPTION
Allow system metrics to be collected with custom dimensions attached.

### Motivation:

At the moment, when recording system metrics, each system metric (resident memory, number of file descriptors) is recorded with custom label as a `Gauge`. But nothing else. This pull requests allow custom labels to be attached to each `Gauge` to better identify the process, machine, etc...

### Modifications:

Both `swift-metrics` as well as `prometheus` implementations allow all metric types  (`Counter`, `Gauge`, etc) to specify their `name` (Also called `label` in this repo) and custom `dimensions` (other labels attached to the metric. This pull request allows to attach custom `dimensions` to each `Gauge` recorded.

### Result:

You can now fine tune the `dimensions` (prometheus `labels`) attached to each collected metric. Via config. For example in the example below all gauges are annotated with "process" label set to "my_fancy_binary" allowing easier visualization in Prometheus/Grafana in cases where you are monitoring multiple processes, etc.

```
public extension SystemMetrics.Configuration {
    static let prometheus = SystemMetrics.Configuration(
        labels: .init(
            prefix: "process_",
            virtualMemoryBytes: "virtual_memory_bytes",
            residentMemoryBytes: "resident_memory_bytes",
            startTimeSeconds: "start_time_seconds",
            cpuSecondsTotal: "cpu_seconds_total",
            maxFds: "max_fds",
            openFds: "open_fds"
        ),
        dimensions: [("process", "my_fancy_binary")]
    )
}```
