### PR TITLE
Add CPU usage to reported metrics

### DIFF
--- a/Sources/SystemMetrics/SystemMetrics.swift
+++ b/Sources/SystemMetrics/SystemMetrics.swift
@@ -203,7 +203,7 @@ public enum SystemMetrics {
         /// Number of open file descriptors.
         var openFileDescriptors: Int
         /// CPU usage percentage.
-        var cpuUsage: Float
+        var cpuUsage: Double
     }
 
     #if os(Linux)
@@ -353,12 +353,12 @@ public enum SystemMetrics {
         }
         let startTimeInSecondsSinceEpoch = systemStartTimeInSecondsSinceEpoch + processStartTimeInSeconds
 
-        var cpuUsage: Float = 0
+        var cpuUsage: Double = 0
         if cpuSeconds > 0 {
             guard let uptimeString = uptimeFileContents.split(separator: " ").first,
-                  let uptimeSeconds = Float(uptimeString)
+                  let uptimeSeconds = Double(uptimeString)
             else { return nil }
-            cpuUsage = (Float(cpuSeconds) * 100 / (uptimeSeconds - Float(processStartTimeInSeconds)))
+            cpuUsage = (Double(cpuSeconds) * 100 / (uptimeSeconds - Double(processStartTimeInSeconds)))
         }
 
         var _rlim = rlimit()

--- a/Tests/SystemMetricsTests/SystemMetricsTests.swift
+++ b/Tests/SystemMetricsTests/SystemMetricsTests.swift
@@ -33,10 +33,20 @@ class SystemMetricsTest: XCTestCase {
         XCTAssertNotNil(metrics.cpuSeconds)
         XCTAssertNotNil(metrics.maxFileDescriptors)
         XCTAssertNotNil(metrics.openFileDescriptors)
+        XCTAssertNotNil(metrics.cpuUsage)
     }
 
     func testSystemMetricsLabels() throws {
-        let labels = SystemMetrics.Labels(prefix: "pfx+", virtualMemoryBytes: "vmb", residentMemoryBytes: "rmb", startTimeSeconds: "sts", cpuSecondsTotal: "cpt", maxFds: "mfd", openFds: "ofd")
+        let labels = SystemMetrics.Labels(
+            prefix: "pfx+",
+            virtualMemoryBytes: "vmb",
+            residentMemoryBytes: "rmb",
+            startTimeSeconds: "sts",
+            cpuSecondsTotal: "cpt",
+            maxFds: "mfd",
+            openFds: "ofd",
+            cpuUsage: "cpu"
+        )
 
         XCTAssertEqual(labels.label(for: \.virtualMemoryBytes), "pfx+vmb")
         XCTAssertEqual(labels.label(for: \.residentMemoryBytes), "pfx+rmb")
@@ -44,10 +54,20 @@ class SystemMetricsTest: XCTestCase {
         XCTAssertEqual(labels.label(for: \.cpuSecondsTotal), "pfx+cpt")
         XCTAssertEqual(labels.label(for: \.maxFileDescriptors), "pfx+mfd")
         XCTAssertEqual(labels.label(for: \.openFileDescriptors), "pfx+ofd")
+        XCTAssertEqual(labels.label(for: \.cpuUsage), "pfx+cpu")
     }
 
     func testSystemMetricsConfiguration() throws {
-        let labels = SystemMetrics.Labels(prefix: "pfx_", virtualMemoryBytes: "vmb", residentMemoryBytes: "rmb", startTimeSeconds: "sts", cpuSecondsTotal: "cpt", maxFds: "mfd", openFds: "ofd")
+        let labels = SystemMetrics.Labels(
+            prefix: "pfx_",
+            virtualMemoryBytes: "vmb",
+            residentMemoryBytes: "rmb",
+            startTimeSeconds: "sts",
+            cpuSecondsTotal: "cpt",
+            maxFds: "mfd",
+            openFds: "ofd",
+            cpuUsage: "cpu"
+        )
         let dimensions = [("app", "example"), ("environment", "production")]
         let configuration = SystemMetrics.Configuration(pollInterval: .microseconds(123_456_789), labels: labels, dimensions: dimensions)
 
@@ -61,6 +81,7 @@ class SystemMetricsTest: XCTestCase {
         XCTAssertEqual(configuration.labels.label(for: \.cpuSecondsTotal), "pfx_cpt")
         XCTAssertEqual(configuration.labels.label(for: \.maxFileDescriptors), "pfx_mfd")
         XCTAssertEqual(configuration.labels.label(for: \.openFileDescriptors), "pfx_ofd")
+        XCTAssertEqual(configuration.labels.label(for: \.cpuUsage), "pfx_cpu")
 
         XCTAssertTrue(configuration.dimensions.contains(where: { $0 == ("app", "example") }))
         XCTAssertTrue(configuration.dimensions.contains(where: { $0 == ("environment", "production") }))


### PR DESCRIPTION
## Description

We are currently reporting a set of metrics taken from the [Prometheus Client Library guidelines](https://prometheus.io/docs/instrumenting/writing_clientlibs/#standard-and-runtime-collectors), which is fine, but is sometimes not enough to calculate CPU usage. 

The reason for this is that to calculate the CPU usage of a process `P`, we need to divide the CPU time used by `P`, by the amount of time the process has been running. However, we don't currently have the uptime of `P`, since  the "start time" metric we report is a constant - the number of seconds after system boot that the process was started. 
This PR gets the uptime of the system (by reading `/proc/uptime`) and uses that and the information we currently gather to calculate CPU usage, and report that as a new metric.

Furthermore, the start time metric was actually not adhering to the Prometheus guidelines, since it's stated that it should be the number of seconds since the epoch that the process was started, but we're reporting the number of seconds after system boot that the process started (taken from `/proc/stat`). This PR fixes this as well.