### PR TITLE
Fix potential arithmetic errors in CPU usage calculator

### DIFF
--- a/Tests/SystemMetricsTests/SystemMetricsTests+XCTest.swift
+++ b/Tests/SystemMetricsTests/SystemMetricsTests+XCTest.swift
@@ -28,6 +28,7 @@ extension SystemMetricsTest {
             ("testSystemMetricsGeneration", testSystemMetricsGeneration),
             ("testSystemMetricsLabels", testSystemMetricsLabels),
             ("testSystemMetricsConfiguration", testSystemMetricsConfiguration),
+            ("testCPUUsageCalculator", testCPUUsageCalculator),
         ]
     }
 }

--- a/Tests/SystemMetricsTests/SystemMetricsTests.swift
+++ b/Tests/SystemMetricsTests/SystemMetricsTests.swift
@@ -21,10 +21,6 @@ class SystemMetricsTest: XCTestCase {
     func testSystemMetricsGeneration() throws {
         #if os(Linux)
         let _metrics = SystemMetrics.linuxSystemMetrics()
-        #else
-        let _metrics = SystemMetrics.noopSystemMetrics()
-        throw XCTSkip()
-        #endif
         XCTAssertNotNil(_metrics)
         let metrics = _metrics!
         XCTAssertNotNil(metrics.virtualMemoryBytes)
@@ -34,6 +30,9 @@ class SystemMetricsTest: XCTestCase {
         XCTAssertNotNil(metrics.maxFileDescriptors)
         XCTAssertNotNil(metrics.openFileDescriptors)
         XCTAssertNotNil(metrics.cpuUsage)
+        #else
+        throw XCTSkip()
+        #endif
     }
 
     func testSystemMetricsLabels() throws {
@@ -88,5 +87,20 @@ class SystemMetricsTest: XCTestCase {
 
         XCTAssertFalse(configuration.dimensions.contains(where: { $0 == ("environment", "staging") }))
         XCTAssertFalse(configuration.dimensions.contains(where: { $0 == ("process", "example") }))
+    }
+
+    func testCPUUsageCalculator() throws {
+        #if os(Linux)
+        var calculator = SystemMetrics.CPUUsageCalculator()
+        var usage = calculator.getUsagePercentage(ticksSinceSystemBoot: 0, cpuTicks: 0)
+        XCTAssertFalse(usage.isNaN)
+        XCTAssertEqual(usage, 0)
+
+        usage = calculator.getUsagePercentage(ticksSinceSystemBoot: 20, cpuTicks: 10)
+        XCTAssertFalse(usage.isNaN)
+        XCTAssertEqual(usage, 50)
+        #else
+        throw XCTSkip()
+        #endif
     }
 }


### PR DESCRIPTION
Fix potential arithmetic errors in CPU usage calculator.

### Motivation:

In a project using swift-metrics-extras, we noticed that the CPU usage metric would sometimes be `-nan`, causing issues when encoding to JSON (which our metrics backend does). The lack of logs in swift-metrics(-extras) makes it hard to know for sure why this was happening, but it's possible that if the usage calculator was called in quick succession, the number of uptime ticks (for both the system and the process) could be the same as the previous invocation, causing a `0.0/0.0` division which results in `NaN`. 

### Modifications:

Added some extra checks and tests to make sure that these operations are safer.

### Result:

Hopefully no more `NaN's.