### PR TITLE
Add support for compiling against MUSL

### DIFF
--- a/Tests/SystemMetricsTests/SystemMetricsTests.swift
+++ b/Tests/SystemMetricsTests/SystemMetricsTests.swift
@@ -13,8 +13,10 @@
 //===----------------------------------------------------------------------===//
 @testable import SystemMetrics
 import XCTest
-#if os(Linux)
+#if canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #endif
 
 class SystemMetricsTest: XCTestCase {


### PR DESCRIPTION
This adds support for compiling against MUSL.

### Motivation:

It allows us to build packages using the Static Linux SDK.

### Modifications:

I've added the Musl import, if available and added type casts if needed.

### Result:

The package now builds successfully when using the Static Linux SDK.
