### PR TITLE
Enable macOS CI on pull requests

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -20,3 +20,7 @@ jobs:
       linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
+
+  macos-tests:
+    with:
+      runner_pool: general


### PR DESCRIPTION
Motivation:

* Improve test coverage

Modifications:

Enable macOS CI to be run on pull request commits and make the use of the nightly runner pool for main.yml jobs explicit.

Result:

Improved test coverage.
