### PR TITLE
[SSM-0002] Rename the package to better reflect its purpose

### DIFF
--- a/Sources/SystemMetrics/Docs.docc/Proposals/SSM-0002.md
+++ b/Sources/SystemMetrics/Docs.docc/Proposals/SSM-0002.md
@@ -6,7 +6,7 @@ Rename the package and repository from `swift-metrics-extras` to `swift-system-m
 
 - Proposal: SSM-0002
 - Author(s): [Vladimir Kukushkin](https://github.com/kukushechkin)
-- Status: **In Review**
+- Status: **Ready for Implementation**
 - Issue: [apple/swift-metrics-extras#69](https://github.com/apple/swift-metrics-extras/issues/69)
 - Implementation: TBA
 - Related links:


### PR DESCRIPTION
Introduce a proposal for renaming the package to better reflect its purpose.

### Motivation:

The package name `swift-metrics-extras` suggests a collection of various metrics-related utilities, but the package contains only one component collecting and reporting process system metrics. This creates confusion for potential users and does not accurately describe the package's purpose. A more descriptive name would make it easier for users to discover and understand what the package does.

### Modifications:

"SSM-0002: rename the package" proposal doc added

### Result:

A proposal document added.
