### PR TITLE
Increase the default collection interval

### DIFF
--- a/Examples/ServiceIntegration/Sources/main.swift
+++ b/Examples/ServiceIntegration/Sources/main.swift
@@ -53,7 +53,7 @@ struct Application {
         // Create a service simulating some important work
         let service = FooService(logger: logger)
         let systemMetricsMonitor = SystemMetricsMonitor(
-            configuration: .init(pollInterval: .seconds(5)),
+            configuration: .init(pollInterval: .seconds(30)),
             logger: logger
         )
 

--- a/Sources/SystemMetrics/Docs.docc/GettingStarted.md
+++ b/Sources/SystemMetrics/Docs.docc/GettingStarted.md
@@ -34,7 +34,7 @@ You can configure the polling interval with your own ``SystemMetricsMonitor/Conf
 
 ```swift
 let systemMetricsMonitor = SystemMetricsMonitor(
-    configuration: .init(pollInterval: .seconds(5)),
+    configuration: .init(pollInterval: .seconds(30)),
     logger: logger
 )
 ```
@@ -44,7 +44,7 @@ let systemMetricsMonitor = SystemMetricsMonitor(
 Use [Swift Service Lifecycle](https://github.com/swift-server/swift-service-lifecycle) to run the monitor as a background service with support for graceful shutdown and UNIX signal handling.
 To do so, include the system metrics monitor you created in a service group and run the group in your application.
 
-The following code bootstraps your own metrics backend, creates a system metrics monitor, and uses service lifecycle to run both: 
+The following code bootstraps your own metrics backend, creates a system metrics monitor, and uses service lifecycle to run both:
 
 ```swift
 import SystemMetrics

--- a/Sources/SystemMetrics/SystemMetricsMonitorConfiguration.swift
+++ b/Sources/SystemMetrics/SystemMetricsMonitorConfiguration.swift
@@ -22,7 +22,7 @@ extension SystemMetricsMonitor {
 
         /// The interval between system metrics data scraping.
         ///
-        /// The default interval is 2 seconds.
+        /// The default interval is 15 seconds.
         public var interval: Duration
 
         /// String labels associated with the metrics
@@ -34,9 +34,9 @@ extension SystemMetricsMonitor {
         /// Create new monitor configuration.
         ///
         /// - Parameters:
-        ///     - interval: The interval at which system metrics should be updated, defaults to 2 seconds.
+        ///     - interval: The interval at which system metrics should be updated, defaults to 15 seconds.
         public init(
-            pollInterval interval: Duration = .seconds(2)
+            pollInterval interval: Duration = .seconds(15)
         ) {
             self.interval = interval
             self.labels = .init()
@@ -50,7 +50,7 @@ extension SystemMetricsMonitor {
         ///     - labels: The labels to use for generated system metrics.
         ///     - dimensions: The dimensions to include in generated system metrics.
         package init(
-            pollInterval interval: Duration = .seconds(2),
+            pollInterval interval: Duration = .seconds(15),
             labels: Labels,
             dimensions: [(String, String)] = []
         ) {

--- a/Tests/SystemMetricsTests/SystemMetricsMonitorTests.swift
+++ b/Tests/SystemMetricsTests/SystemMetricsMonitorTests.swift
@@ -291,7 +291,7 @@ struct SystemMetricsMonitorTests {
         // Wait for the monitor to run a few times
         #expect(
             try await wait(
-                noLongerThan: .seconds(2.0),
+                noLongerThan: .seconds(15.0),
                 for: {
                     await provider.getCallCount() >= 3
                 },


### PR DESCRIPTION
Fixes #82 

### Motivation:

Most monitoring tools do not collect the data frequently, so there is no need to update the gauges every 2 seconds if tools are collecting data every 5-30-60 seconds. 15 seconds is a good middle ground.

### Modifications:

Default interval value and the corresponding docs are updated.

### Result:

With the default configuration, system metrics are collected every 15 seconds.
