### PR TITLE
Do not put example service name into the dashboard config

### DIFF
--- a/Examples/ServiceIntegration/grafana/provisioning/dashboards/grafana-dashboard-service-process-metrics.json
+++ b/Examples/ServiceIntegration/grafana/provisioning/dashboards/grafana-dashboard-service-process-metrics.json
@@ -313,7 +313,7 @@
             "uid": "prometheus"
           },
           "editorMode": "builder",
-          "expr": "process_resident_memory_bytes{service_name=\"ServiceIntegrationExample\"}",
+          "expr": "process_resident_memory_bytes",
           "hide": false,
           "instant": false,
           "legendFormat": "Residential Memory",
@@ -326,7 +326,7 @@
             "uid": "prometheus"
           },
           "editorMode": "builder",
-          "expr": "process_virtual_memory_bytes{service_name=\"ServiceIntegrationExample\"}",
+          "expr": "process_virtual_memory_bytes",
           "hide": false,
           "instant": false,
           "legendFormat": "Virtual Memory",


### PR DESCRIPTION
Remove swift-system-metrics ServiceIntegration example name from the example dashboard provisioning.

### Motivation:

With the specific service name hardcoded in the dashboard provisioning config, it is not compatible with other projects where people might want to just copy-paste this config. All other metrics (CPU%, fds) already use values across all the reported dimensions.

### Modifications:

Removed `service_name="ServiceIntegrationExample"` filter from the memory consumption dashboard visualization.

### Result:

Memory dashboard configuration no longer shows memory usage only for the `ServiceIntegrationExample` service. Any project adopting `SystemMetricsMonitor` can now copy-paste the config as-is and get the Process System Metrics dashboard configured automatically in their Grafana.
