### PR TITLE
Remove unsafe flags

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -56,5 +56,6 @@ where [.executable, .test, .regular].contains(
     // https://docs.swift.org/compiler/documentation/diagnostics/nonisolated-nonsending-by-default/
     settings.append(.enableUpcomingFeature("NonisolatedNonsendingByDefault"))
 
+    // Note: do not use .unsafeFlags, this will prevent SPM from checking out the package with tag.
     target.swiftSettings = settings
 }

--- a/Package.swift
+++ b/Package.swift
@@ -56,8 +56,5 @@ where [.executable, .test, .regular].contains(
     // https://docs.swift.org/compiler/documentation/diagnostics/nonisolated-nonsending-by-default/
     settings.append(.enableUpcomingFeature("NonisolatedNonsendingByDefault"))
 
-    // Ensure all public types are explicitly annotated as Sendable or not Sendable.
-    settings.append(.unsafeFlags(["-Xfrontend", "-require-explicit-sendable"]))
-
     target.swiftSettings = settings
 }


### PR DESCRIPTION
Remove unsafe `-require-explicit-sendable` flag.

### Motivation:

Existence of the flag prevents the package tags from being used.

### Modifications:

The flag removed from the Package.swift.

### Result:

Package could be used with a tag.
