### PR TITLE
Support configuring metrics labels

### DIFF
--- a/Sources/SystemMetrics/SystemMetricsMonitor.swift
+++ b/Sources/SystemMetrics/SystemMetricsMonitor.swift
@@ -79,32 +79,32 @@ public struct SystemMetricsMonitor: Service {
         // Initialize gauges once to avoid repeated creation in updateMetrics()
         let effectiveMetricsFactory = metricsFactory ?? MetricsSystem.factory
         self.virtualMemoryBytesGauge = Gauge(
-            label: configuration.labels.label(for: \.virtualMemoryBytes),
+            label: configuration.labels.virtualMemoryBytes,
             dimensions: configuration.dimensions,
             factory: effectiveMetricsFactory
         )
         self.residentMemoryBytesGauge = Gauge(
-            label: configuration.labels.label(for: \.residentMemoryBytes),
+            label: configuration.labels.residentMemoryBytes,
             dimensions: configuration.dimensions,
             factory: effectiveMetricsFactory
         )
         self.startTimeSecondsGauge = Gauge(
-            label: configuration.labels.label(for: \.startTimeSeconds),
+            label: configuration.labels.startTimeSeconds,
             dimensions: configuration.dimensions,
             factory: effectiveMetricsFactory
         )
         self.cpuSecondsTotalGauge = Gauge(
-            label: configuration.labels.label(for: \.cpuSecondsTotal),
+            label: configuration.labels.cpuSecondsTotal,
             dimensions: configuration.dimensions,
             factory: effectiveMetricsFactory
         )
         self.maxFileDescriptorsGauge = Gauge(
-            label: configuration.labels.label(for: \.maxFileDescriptors),
+            label: configuration.labels.maxFileDescriptors,
             dimensions: configuration.dimensions,
             factory: effectiveMetricsFactory
         )
         self.openFileDescriptorsGauge = Gauge(
-            label: configuration.labels.label(for: \.openFileDescriptors),
+            label: configuration.labels.openFileDescriptors,
             dimensions: configuration.dimensions,
             factory: effectiveMetricsFactory
         )

--- a/Sources/SystemMetrics/SystemMetricsMonitorConfiguration.swift
+++ b/Sources/SystemMetrics/SystemMetricsMonitorConfiguration.swift
@@ -26,7 +26,7 @@ extension SystemMetricsMonitor {
         public var interval: Duration
 
         /// String labels associated with the metrics
-        package let labels: SystemMetricsMonitor.Configuration.Labels
+        public var labels: Labels
 
         /// Additional dimensions attached to every metric
         package let dimensions: [(String, String)]
@@ -39,7 +39,7 @@ extension SystemMetricsMonitor {
             pollInterval interval: Duration = .seconds(15)
         ) {
             self.interval = interval
-            self.labels = .init()
+            self.labels = Labels()
             self.dimensions = []
         }
 
@@ -66,34 +66,22 @@ extension SystemMetricsMonitor.Configuration {
     ///
     /// Backend implementations can provide a static extension with
     /// defaults that suit their specific backend needs.
-    package struct Labels: Sendable {
-        /// Prefix for all other labels.
-        package var prefix: String = "process_"
+    public struct Labels: Sendable {
         /// Label for virtual memory size in bytes.
-        package var virtualMemoryBytes: String = "virtual_memory_bytes"
+        public var virtualMemoryBytes: String = "process_virtual_memory_bytes"
         /// Label for resident memory size in bytes.
-        package var residentMemoryBytes: String = "resident_memory_bytes"
+        public var residentMemoryBytes: String = "process_resident_memory_bytes"
         /// Label for process start time since UNIX epoch in seconds.
-        package var startTimeSeconds: String = "start_time_seconds"
+        public var startTimeSeconds: String = "process_start_time_seconds"
         /// Label for total user and system CPU time spent in seconds.
-        package var cpuSecondsTotal: String = "cpu_seconds_total"
+        public var cpuSecondsTotal: String = "process_cpu_seconds_total"
         /// Label for maximum number of open file descriptors.
-        package var maxFileDescriptors: String = "max_fds"
+        public var maxFileDescriptors: String = "process_max_fds"
         /// Label for number of open file descriptors.
-        package var openFileDescriptors: String = "open_fds"
-
-        /// Construct a label for a metric by concatenating the prefix with the corresponding label.
-        ///
-        /// - Parameters:
-        ///     - for: The property to construct the label for.
-        package func label(for keyPath: KeyPath<Labels, String>) -> String {
-            self.prefix + self[keyPath: keyPath]
-        }
+        public var openFileDescriptors: String = "process_open_fds"
 
         /// Create a new `Labels` instance with default values.
-        ///
-        package init() {
-        }
+        public init() {}
 
         /// Create a new `Labels` instance.
         ///
@@ -114,13 +102,12 @@ extension SystemMetricsMonitor.Configuration {
             maxFileDescriptors: String,
             openFileDescriptors: String
         ) {
-            self.prefix = prefix
-            self.virtualMemoryBytes = virtualMemoryBytes
-            self.residentMemoryBytes = residentMemoryBytes
-            self.startTimeSeconds = startTimeSeconds
-            self.cpuSecondsTotal = cpuSecondsTotal
-            self.maxFileDescriptors = maxFileDescriptors
-            self.openFileDescriptors = openFileDescriptors
+            self.virtualMemoryBytes = prefix + virtualMemoryBytes
+            self.residentMemoryBytes = prefix + residentMemoryBytes
+            self.startTimeSeconds = prefix + startTimeSeconds
+            self.cpuSecondsTotal = prefix + cpuSecondsTotal
+            self.maxFileDescriptors = prefix + maxFileDescriptors
+            self.openFileDescriptors = prefix + openFileDescriptors
         }
     }
 }

--- a/Tests/SystemMetricsTests/SystemMetricsMonitorTests.swift
+++ b/Tests/SystemMetricsTests/SystemMetricsMonitorTests.swift
@@ -48,12 +48,12 @@ struct SystemMetricsMonitorTests {
             openFileDescriptors: "ofd"
         )
 
-        #expect(labels.label(for: \.virtualMemoryBytes) == "pfx+vmb")
-        #expect(labels.label(for: \.residentMemoryBytes) == "pfx+rmb")
-        #expect(labels.label(for: \.startTimeSeconds) == "pfx+sts")
-        #expect(labels.label(for: \.cpuSecondsTotal) == "pfx+cpt")
-        #expect(labels.label(for: \.maxFileDescriptors) == "pfx+mfd")
-        #expect(labels.label(for: \.openFileDescriptors) == "pfx+ofd")
+        #expect(labels.virtualMemoryBytes == "pfx+vmb")
+        #expect(labels.residentMemoryBytes == "pfx+rmb")
+        #expect(labels.startTimeSeconds == "pfx+sts")
+        #expect(labels.cpuSecondsTotal == "pfx+cpt")
+        #expect(labels.maxFileDescriptors == "pfx+mfd")
+        #expect(labels.openFileDescriptors == "pfx+ofd")
     }
 
     @Test("Configuration preserves all provided settings")
@@ -76,12 +76,12 @@ struct SystemMetricsMonitorTests {
 
         #expect(configuration.interval == .microseconds(123_456_789))
 
-        #expect(configuration.labels.label(for: \.virtualMemoryBytes) == "pfx_vmb")
-        #expect(configuration.labels.label(for: \.residentMemoryBytes) == "pfx_rmb")
-        #expect(configuration.labels.label(for: \.startTimeSeconds) == "pfx_sts")
-        #expect(configuration.labels.label(for: \.cpuSecondsTotal) == "pfx_cpt")
-        #expect(configuration.labels.label(for: \.maxFileDescriptors) == "pfx_mfd")
-        #expect(configuration.labels.label(for: \.openFileDescriptors) == "pfx_ofd")
+        #expect(configuration.labels.virtualMemoryBytes == "pfx_vmb")
+        #expect(configuration.labels.residentMemoryBytes == "pfx_rmb")
+        #expect(configuration.labels.startTimeSeconds == "pfx_sts")
+        #expect(configuration.labels.cpuSecondsTotal == "pfx_cpt")
+        #expect(configuration.labels.maxFileDescriptors == "pfx_mfd")
+        #expect(configuration.labels.openFileDescriptors == "pfx_ofd")
 
         #expect(configuration.dimensions.contains(where: { $0 == ("app", "example") }))
         #expect(configuration.dimensions.contains(where: { $0 == ("environment", "production") }))


### PR DESCRIPTION
Support configuring metrics labels by making `labels` configuration part of the public interface.

### Motivation:

Users might want to customize the labels of the system metrics this library collects. For example, some might prefer using the OpenTelemetry Semantic Conventions for [Process Metrics](https://opentelemetry.io/docs/specs/semconv/system/process-metrics/).

### Modifications:

We made `SystemMetricsMonitor.Configuration.Labels` part of the public interface and `labels` a mutable property. This strongly reflects how we, e.g., deal with logging key configuration in the ecosystem (e.g., see the [`LoggingConfiguration`](https://github.com/swift-server/swift-service-lifecycle/blob/1de37290c0ab3c5a96028e0f02911b672fd42348/Sources/ServiceLifecycle/ServiceGroupConfiguration.swift#L26-L51) of swift-service-lifecycle) to make sure we are consistent.
This also meant we removed the `prefix` property in `Labels`.

### Result:

Library users can now freely adjust the metric labels.
