### PR TITLE
Enable nightly tests on simulators to gather flakiness statistics

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,20 @@ jobs:
     with:
       runner_pool: nightly
       build_scheme: swift-system-metrics
+      debug_output_enabled: true
+      xcode_16_3_enabled: false
+      xcode_16_4_enabled: false
+      xcode_26_0_enabled: false
+      xcode_26_1_enabled: false
+      xcode_26_2_enabled: false
+      swift_6_1_enabled: true
+      swift_6_2_enabled: true
+      swift_6_3_enabled: true
+      macos_xcode_test_enabled: true
+      ios_xcode_test_enabled: true
+      watchos_xcode_test_enabled: true
+      tvos_xcode_test_enabled: true
+      visionos_xcode_test_enabled: true
 
   static-sdk:
     name: Static SDK


### PR DESCRIPTION
We need to gather some statistics on the flakiness of the simulators in CI. This repo seems like a good candidate — the package is quite stable and not that popular to raise questions.
