### PR TITLE
Suggest using `MappingMetricsFactory` from `swift-metrics`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .library(name: "SystemMetrics", targets: ["SystemMetrics"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-metrics.git", from: "2.7.1"),
+        .package(url: "https://github.com/apple/swift-metrics.git", from: "2.10.0"),
         .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", from: "2.9.1"),
         .package(url: "https://github.com/apple/swift-async-algorithms", from: "1.1.1"),
     ],

--- a/README.md
+++ b/README.md
@@ -85,6 +85,13 @@ The monitor collects and reports the following metrics as gauges:
 - **Thread Count**: The number of threads in the process.
   - Metric name: `process_thread_count`
 
+## Renaming metric labels
+
+If your metrics backend expects different label names, use `MappingMetricsFactory` from Swift Metrics to rename labels
+without modifying the library itself. See the
+[Getting Started](https://swiftpackageindex.com/apple/swift-system-metrics/documentation/systemmetrics/gettingstarted)
+guide for a complete example.
+
 ## Supported platforms and minimum versions
 
 The library is supported on macOS and Linux.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ The monitor collects and reports the following metrics as gauges:
   - Metric name: `process_max_fds`
 - **Open File Descriptors**: The number of file descriptors the process currently has open.
   - Metric name: `process_open_fds`
+- **Thread Count**: The number of threads in the process.
+  - Metric name: `process_thread_count`
 
 ## Supported platforms and minimum versions
 

--- a/Sources/SystemMetrics/Docs.docc/GettingStarted.md
+++ b/Sources/SystemMetrics/Docs.docc/GettingStarted.md
@@ -73,3 +73,37 @@ struct Application {
     }
 }
 ```
+
+### Rename metric labels
+
+If your metrics backend expects different label names, use `MappingMetricsFactory` from Swift Metrics to rename labels
+without modifying the library:
+
+```swift
+import CoreMetrics
+
+let myBackend = MyMetricsBackendImplementation()
+MetricsSystem.bootstrap(myBackend)
+
+let labelMapping: [String: String] = [
+    "process_virtual_memory_bytes": "my_app_vm_bytes",
+    "process_resident_memory_bytes": "my_app_rm_bytes",
+    "process_start_time_seconds": "my_app_start_time",
+    "process_cpu_seconds_total": "my_app_cpu_total",
+    "process_max_fds": "my_app_max_fds",
+    "process_open_fds": "my_app_open_fds",
+    "process_thread_count": "my_app_threads",
+]
+
+let mappingFactory = MetricsSystem.factory.withLabelAndDimensionsMapping { label, dimensions in
+    (labelMapping[label] ?? label, dimensions)
+}
+
+let systemMetricsMonitor = SystemMetricsMonitor(
+    metricsFactory: mappingFactory,
+    logger: logger
+)
+```
+
+The transform receives every label and its dimensions before the metric is created. Labels not in the dictionary are
+passed through unchanged.

--- a/Sources/SystemMetrics/Docs.docc/index.md
+++ b/Sources/SystemMetrics/Docs.docc/index.md
@@ -75,6 +75,12 @@ The monitor collects the following metrics:
 
 > Note: New metrics can be added in minor and patch versions.
 
+### Rename metric labels
+
+If your metrics backend expects different label names, use
+[`MappingMetricsFactory`](https://swiftpackageindex.com/apple/swift-metrics/documentation/coremetrics/mappingmetricsfactory)
+from Swift Metrics to rename labels without modifying the library. See <doc:GettingStarted> for a complete example.
+
 ### Supported platforms and minimum versions
 
 The library is supported on macOS and Linux.

--- a/Tests/SystemMetricsTests/SystemMetricsMonitorTests.swift
+++ b/Tests/SystemMetricsTests/SystemMetricsMonitorTests.swift
@@ -355,6 +355,76 @@ struct SystemMetricsMonitorTests {
         #expect(lastValue > 0)
         #endif
     }
+
+    @Test("MappingMetricsFactory renames all default labels")
+    func monitorWithMappingFactory() async throws {
+        let logger = Logger(label: "SystemMetricsMonitorTests")
+        let mockData = SystemMetricsMonitor.Data(
+            virtualMemoryBytes: 1000,
+            residentMemoryBytes: 2000,
+            startTimeSeconds: 3000,
+            cpuSeconds: 4000,
+            maxFileDescriptors: 5000,
+            openFileDescriptors: 6000,
+            threadCount: 7000
+        )
+
+        let provider = MockMetricsProvider(mockData: mockData)
+        let testMetrics = TestMetrics()
+
+        // Rename every label using a dictionary. This pins the exact
+        // default label names the library uses, so the test fails if
+        // any label is accidentally changed.
+        let labelMapping: [String: String] = [
+            "process_virtual_memory_bytes": "app_vm_bytes",
+            "process_resident_memory_bytes": "app_rm_bytes",
+            "process_start_time_seconds": "app_start_time",
+            "process_cpu_seconds_total": "app_cpu_total",
+            "process_max_fds": "app_max_fds",
+            "process_open_fds": "app_open_fds",
+            "process_thread_count": "app_threads",
+        ]
+
+        let mappingFactory = testMetrics.withLabelAndDimensionsMapping { label, dimensions in
+            guard let mapped = labelMapping[label] else {
+                preconditionFailure("Unexpected metric label: \(label)")
+            }
+            return (mapped, dimensions)
+        }
+
+        let monitor = SystemMetricsMonitor(
+            configuration: .init(pollInterval: .seconds(1)),
+            metricsFactory: mappingFactory,
+            dataProvider: provider,
+            logger: logger
+        )
+
+        await monitor.updateMetrics()
+
+        let vmGauge = try testMetrics.expectGauge("app_vm_bytes")
+        #expect(vmGauge.lastValue == 1000)
+
+        let rmbGauge = try testMetrics.expectGauge("app_rm_bytes")
+        #expect(rmbGauge.lastValue == 2000)
+
+        let stsGauge = try testMetrics.expectGauge("app_start_time")
+        #expect(stsGauge.lastValue == 3000)
+
+        let cpuGauge = try testMetrics.expectGauge("app_cpu_total")
+        #expect(cpuGauge.lastValue == 4000)
+
+        let mfdGauge = try testMetrics.expectGauge("app_max_fds")
+        #expect(mfdGauge.lastValue == 5000)
+
+        let ofdGauge = try testMetrics.expectGauge("app_open_fds")
+        #expect(ofdGauge.lastValue == 6000)
+
+        let tcGauge = try testMetrics.expectGauge("app_threads")
+        #expect(tcGauge.lastValue == 7000)
+
+        // Verify that exactly 7 gauges were created — no more, no fewer.
+        #expect(testMetrics.recorders.count == 7)
+    }
 }
 
 @Suite("SystemMetrics with MetricsSystem Initialization Tests", .serialized)


### PR DESCRIPTION
Document the recommended way of customizing metric labels and dimensions created by the Swift System Metrics.

### Motivation:

Swift System Metrics creates metric objects with specific labels. These labels are in prometheus notation. To make Swift System Metrics compatible with other metrics tools, we need a way to customize the labels. Swift Metrics has recently received an updated with a metrics factory providing a way to centrally adjust metric labels and dimensions on the factory level.

### Modifications:

- The recommended way of customizing metric labels created by the Swift System Metrics.

### Result:

Swift System Metrics users can customize system metric labels according to the backend specs of their choice.
