### PR TITLE
Make dependabot set  label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    labels:
+      - "semver/none"


### PR DESCRIPTION
Prompt: Make dependabot set  label

Claude output:
The file already has both changes applied:
- The schedule interval is already set to `"daily"`
- The label `"semver/none"` is already configured

No further changes needed — the dependabot.yml is already up to date.
