### PR TITLE
Fix Linux open file descriptor count being inflated by 2 due to counting . and .. directory entries

### DIFF
--- a/Sources/SystemMetrics/SystemMetricsMonitor+Linux.swift
+++ b/Sources/SystemMetrics/SystemMetricsMonitor+Linux.swift
@@ -286,12 +286,16 @@ extension SystemMetricsMonitorDataProvider: SystemMetricsProvider {
             // they are not file descriptors.
             let isDot = withUnsafePointer(to: entry.pointee.d_name) {
                 $0.withMemoryRebound(to: CChar.self, capacity: 3) { name in
-                    name[0] == 0x2E /* "." */
+                    // 0x2E is ASCII for "."
+                    name[0] == 0x2E
                         && (name[1] == 0 || (name[1] == 0x2E && name[2] == 0))
                 }
             }
             if !isDot { openFileDescriptors += 1 }
         }
+        // Subtract 1 to exclude the file descriptor opened by opendir()
+        // itself, which appears in /proc/self/fd during enumeration.
+        openFileDescriptors -= 1
 
         return .init(
             virtualMemoryBytes: virtualMemoryBytes,

--- a/Sources/SystemMetrics/SystemMetricsMonitor+Linux.swift
+++ b/Sources/SystemMetrics/SystemMetricsMonitor+Linux.swift
@@ -281,7 +281,17 @@ extension SystemMetricsMonitorDataProvider: SystemMetricsProvider {
             closedir(dir)
         }
         var openFileDescriptors = 0
-        while readdir(dir) != nil { openFileDescriptors += 1 }
+        while let entry = readdir(dir) {
+            // Skip the "." and ".." directory pseudo-entries;
+            // they are not file descriptors.
+            let isDot = withUnsafePointer(to: entry.pointee.d_name) {
+                $0.withMemoryRebound(to: CChar.self, capacity: 3) { name in
+                    name[0] == 0x2E /* "." */
+                        && (name[1] == 0 || (name[1] == 0x2E && name[2] == 0))
+                }
+            }
+            if !isDot { openFileDescriptors += 1 }
+        }
 
         return .init(
             virtualMemoryBytes: virtualMemoryBytes,

--- a/Sources/SystemMetrics/SystemMetricsMonitor+Linux.swift
+++ b/Sources/SystemMetrics/SystemMetricsMonitor+Linux.swift
@@ -293,17 +293,15 @@ extension SystemMetricsMonitorDataProvider: SystemMetricsProvider {
             }
             if !isDot { openFileDescriptors += 1 }
         }
-        // Subtract 1 to exclude the file descriptor opened by opendir()
-        // itself, which appears in /proc/self/fd during enumeration.
-        openFileDescriptors -= 1
-
         return .init(
             virtualMemoryBytes: virtualMemoryBytes,
             residentMemoryBytes: residentMemoryBytes,
             startTimeSeconds: startTimeInSecondsSinceEpoch,
             cpuSeconds: cpuSecondsTotal,
             maxFileDescriptors: maxFileDescriptors,
-            openFileDescriptors: openFileDescriptors,
+            // Subtract 1 to exclude the file descriptor opened by opendir()
+            // itself, which appears in /proc/self/fd during enumeration.
+            openFileDescriptors: max(openFileDescriptors - 1, 0),
             threadCount: threadCount
         )
     }

--- a/Tests/SystemMetricsTests/LinuxDataProviderTests.swift
+++ b/Tests/SystemMetricsTests/LinuxDataProviderTests.swift
@@ -19,7 +19,11 @@ import Glibc
 
 import SystemMetrics
 
-@Suite("Linux Data Provider Tests")
+// This suite is serialized, as the tests involve exercising and
+// measuring process metrics, so running them concurrently can
+// make measurements flaky.
+
+@Suite("Linux Data Provider Tests", .serialized)
 struct LinuxDataProviderTests {
     @Test("Linux system metrics generation provides all required metrics")
     func systemMetricsGeneration() async throws {

--- a/Tests/SystemMetricsTests/LinuxDataProviderTests.swift
+++ b/Tests/SystemMetricsTests/LinuxDataProviderTests.swift
@@ -126,5 +126,22 @@ struct LinuxDataProviderTests {
         #expect(metrics.maxFileDescriptors > 0)
         #expect(metrics.openFileDescriptors > 0)
     }
+
+    @Test("File descriptor counts are accurate")
+    func openFileDescriptors() throws {
+        let metricsBefore = SystemMetricsMonitorDataProvider.linuxSystemMetrics()
+        let openBefore = try #require(metricsBefore?.openFileDescriptors)
+
+        let fd = open("/dev/null", O_RDONLY)
+        guard fd >= 0 else {
+            Issue.record("Failed to open /dev/null")
+            return
+        }
+        defer { close(fd) }
+
+        let metricsDuring = SystemMetricsMonitorDataProvider.linuxSystemMetrics()
+        let openDuring = try #require(metricsDuring?.openFileDescriptors)
+        #expect(openDuring == openBefore + 1)
+    }
 }
 #endif


### PR DESCRIPTION
Fix Linux open file descriptor count being inflated by 2 due to counting "." and ".." directory entries

### Motivation:

The `linuxSystemMetrics()` function collects the number of open file descriptors by enumerating the `/proc/self/fd` directory. The previous implementation used a `readdir` loop that counted every entry in the directory, which inadvertently included the `.` and `..` pseudo-entries. This caused the reported metric to always be inflated by 2 above the actual number of open file descriptors.

### Modifications:

- Updated `linuxSystemMetrics()` in `SystemMetricsMonitor+Linux.swift` to check `d_name` and skip the `.` and `..` entries. This is done by directly checking the bytes to avoid allocating a String for every iteration.

- Added a new `openFileDescriptors()` test to `LinuxDataProviderTests.swift` that mirrors the existing Darwin test by verifying that opening `/dev/null` increases the open file descriptor count by exactly 1.


### Result:
The `process_open_fds` metric on Linux will now accurately reflect the exact number of file descriptors open by the process, aligning its behavior with the Darwin implementation.