### PR TITLE
Fix integer truncation in process start time to preserve sub-second precision

### DIFF
--- a/Sources/SystemMetrics/SystemMetricsMonitor+Darwin.swift
+++ b/Sources/SystemMetrics/SystemMetricsMonitor+Darwin.swift
@@ -66,7 +66,8 @@ extension SystemMetricsMonitorDataProvider: SystemMetricsProvider {
         return .init(
             virtualMemoryBytes: virtualMemoryBytes,
             residentMemoryBytes: residentMemoryBytes,
-            startTimeSeconds: Int(taskInfo.pbsd.pbi_start_tvsec),
+            startTimeSeconds: Double(taskInfo.pbsd.pbi_start_tvsec)
+                + Double(taskInfo.pbsd.pbi_start_tvusec) / 1_000_000.0,
             cpuSeconds: cpuTimeSeconds,
             maxFileDescriptors: fileCounts.maximum,
             openFileDescriptors: fileCounts.open,

--- a/Sources/SystemMetrics/SystemMetricsMonitor+Linux.swift
+++ b/Sources/SystemMetrics/SystemMetricsMonitor+Linux.swift
@@ -231,7 +231,8 @@ extension SystemMetricsMonitorDataProvider: SystemMetricsProvider {
         else { return nil }
 
         let residentMemoryBytes = rss * SystemConfiguration.pageByteCount
-        let processStartTimeInSeconds = startTimeTicks / SystemConfiguration.clockTicksPerSecond
+        let processStartTimeInSeconds =
+            Double(startTimeTicks) / Double(SystemConfiguration.clockTicksPerSecond)
 
         // Use getrusage(RUSAGE_SELF) system call to get CPU time consumption
         // This provides both user and system time spent by this process
@@ -255,7 +256,8 @@ extension SystemMetricsMonitorDataProvider: SystemMetricsProvider {
         guard let systemStartTimeInSecondsSinceEpoch = Self.systemStartTimeInSecondsSinceEpoch else {
             return nil
         }
-        let startTimeInSecondsSinceEpoch = systemStartTimeInSecondsSinceEpoch + processStartTimeInSeconds
+        let startTimeInSecondsSinceEpoch =
+            Double(systemStartTimeInSecondsSinceEpoch) + processStartTimeInSeconds
 
         // Use getrlimit(RLIMIT_NOFILE) system call to get file descriptor limits
         var _rlim = rlimit()

--- a/Sources/SystemMetrics/SystemMetricsMonitor.swift
+++ b/Sources/SystemMetrics/SystemMetricsMonitor.swift
@@ -271,7 +271,7 @@ extension SystemMetricsMonitor {
         /// Resident memory size in bytes.
         package var residentMemoryBytes: Int
         /// Start time of the process since UNIX epoch in seconds.
-        package var startTimeSeconds: Int
+        package var startTimeSeconds: Double
         /// Total user and system CPU time spent in seconds.
         package var cpuSeconds: Double
         /// Maximum number of open file descriptors.
@@ -294,7 +294,7 @@ extension SystemMetricsMonitor {
         package init(
             virtualMemoryBytes: Int,
             residentMemoryBytes: Int,
-            startTimeSeconds: Int,
+            startTimeSeconds: Double,
             cpuSeconds: Double,
             maxFileDescriptors: Int,
             openFileDescriptors: Int,

--- a/Tests/SystemMetricsTests/DarwinDataProviderTests.swift
+++ b/Tests/SystemMetricsTests/DarwinDataProviderTests.swift
@@ -113,7 +113,8 @@ struct DarwinDataProviderTests {
             return
         }
 
-        let expectedStartTime = Double(proc.kp_proc.p_starttime.tv_sec)
+        let expectedStartTime =
+            Double(proc.kp_proc.p_starttime.tv_sec)
             + Double(proc.kp_proc.p_starttime.tv_usec) / 1_000_000.0
         let metricsStartTime = try readMetric(\.startTimeSeconds)
 

--- a/Tests/SystemMetricsTests/DarwinDataProviderTests.swift
+++ b/Tests/SystemMetricsTests/DarwinDataProviderTests.swift
@@ -113,11 +113,13 @@ struct DarwinDataProviderTests {
             return
         }
 
-        let expectedStartTime = proc.kp_proc.p_starttime.tv_sec
+        let expectedStartTime = Double(proc.kp_proc.p_starttime.tv_sec)
+            + Double(proc.kp_proc.p_starttime.tv_usec) / 1_000_000.0
         let metricsStartTime = try readMetric(\.startTimeSeconds)
 
-        // We're ignoring sub-second precision in the test-generated
-        // timestamp, so allow for the metrics data to round up or down.
+        // Allow up to 1 second of drift between the sysctl measurement
+        // and the metrics snapshot, since both calls happen at slightly
+        // different wall-clock times.
         #expect(abs(metricsStartTime - expectedStartTime) <= 1)
     }
 


### PR DESCRIPTION

Fix integer truncation in process start time to preserve sub-second precision

### Motivation:

This PR fixes a bug where the `process_start_time_seconds` metric was being calculated using integer division, causing the sub-second fractional component of the start time to be silently truncated. This resulted in the reported metric being inaccurate by up to ~1 second.

### Modifications:

- Updated the `SystemMetricsMonitor.Data` struct to store `startTimeSeconds` as a `Double` instead of an `Int` to preserve fractional seconds.
- Linux: Converted `startTimeTicks` and `clockTicksPerSecond` to `Double` prior to division in `SystemMetricsMonitor+Linux.swift` to prevent integer truncation.
- Darwin: Included the `pbi_start_tvusec` (microseconds) field from `kinfo_proc` to properly calculate the fractional component in `SystemMetricsMonitor+Darwin.swift`.
- Updated `DarwinDataProviderTests` to compare the `Double` start time metric against the full sub-second timestamp provided by `sysctl`.

### Result:

This aligns the process start time precision with how CPU time is currently computed and with Prometheus metric conventions.
