### PR TITLE
Fix process_max_fds to use soft limit (rlim_cur) on Linux

### DIFF
--- a/Sources/SystemMetrics/SystemMetricsMonitor+Linux.swift
+++ b/Sources/SystemMetrics/SystemMetricsMonitor+Linux.swift
@@ -272,7 +272,7 @@ extension SystemMetricsMonitorDataProvider: SystemMetricsProvider {
             )
         else { return nil }
 
-        let maxFileDescriptors = Int(_rlim.rlim_max)
+        let maxFileDescriptors = Int(_rlim.rlim_cur)
 
         // Count open file descriptors by enumerating /proc/self/fd directory
         // Each entry represents an open file descriptor for this process

--- a/Tests/SystemMetricsTests/DarwinDataProviderTests.swift
+++ b/Tests/SystemMetricsTests/DarwinDataProviderTests.swift
@@ -136,6 +136,19 @@ struct DarwinDataProviderTests {
         #expect(openDuring == openBefore + 1)
     }
 
+    @Test("Max file descriptors reports the soft limit")
+    func maxFileDescriptorsReportsSoftLimit() throws {
+        var limits = rlimit()
+        let result = getrlimit(RLIMIT_NOFILE, &limits)
+        guard result == 0 else {
+            Issue.record("getrlimit failed")
+            return
+        }
+
+        let maxFDs = try readMetric(\.maxFileDescriptors)
+        #expect(maxFDs == Int(limits.rlim_cur))
+    }
+
     @Test("Data provider returns valid metrics via protocol")
     func dataProviderProtocol() async throws {
         let labels = SystemMetricsMonitor.Configuration.Labels(

--- a/Tests/SystemMetricsTests/LinuxDataProviderTests.swift
+++ b/Tests/SystemMetricsTests/LinuxDataProviderTests.swift
@@ -147,5 +147,18 @@ struct LinuxDataProviderTests {
         let openDuring = try #require(metricsDuring?.openFileDescriptors)
         #expect(openDuring == openBefore + 1)
     }
+
+    @Test("Max file descriptors reports the soft limit")
+    func maxFileDescriptorsReportsSoftLimit() throws {
+        var limits = rlimit()
+        let result = getrlimit(__rlimit_resource_t(RLIMIT_NOFILE.rawValue), &limits)
+        guard result == 0 else {
+            Issue.record("getrlimit failed")
+            return
+        }
+
+        let metrics = try #require(SystemMetricsMonitorDataProvider.linuxSystemMetrics())
+        #expect(metrics.maxFileDescriptors == Int(limits.rlim_cur))
+    }
 }
 #endif


### PR DESCRIPTION
Fix `process_max_fds` on Linux to report the soft limit instead of the hard limit.

### Motivation:

While looking at how the monitor works across different platforms, we noticed an inconsistency in how the maximum file descriptors metric (`process_max_fds`) is reported. On Darwin, the monitor correctly fetches the soft limit (`rlim_cur`), which is the actual ceiling the process will hit before things start failing. However, on Linux, it was pulling the hard limit (`rlim_max`). This is pretty misleading because the hard limit on Linux is often set super high or even unlimited, which doesn't reflect the actual enforced limit for the application. The Prometheus convention is also to report the soft limit for this metric.

### Modifications:

- Swapped out `_rlim.rlim_max` for `_rlim.rlim_cur` in `SystemMetricsMonitor+Linux.swift` so it pulls the soft limit.
- Added cross-check tests for both Linux and Darwin to verify that `maxFileDescriptors` actually matches the system's `rlim_cur`.

### Result:

The `process_max_fds` metric on Linux will now accurately report the soft limit, making it consistent with the Darwin implementation and standard Prometheus guidelines. You'll now see the actual number of files your process is allowed to open, rather than a theoretical ceiling.


Thanks to @Renish-patel for helping me writing tests