### PR TITLE
Replace force unwraps with try #require in Linux data provider tests

### DIFF
--- a/Tests/SystemMetricsTests/LinuxDataProviderTests.swift
+++ b/Tests/SystemMetricsTests/LinuxDataProviderTests.swift
@@ -27,9 +27,7 @@ import SystemMetrics
 struct LinuxDataProviderTests {
     @Test("Linux system metrics generation provides all required metrics")
     func systemMetricsGeneration() async throws {
-        let _metrics = SystemMetricsMonitorDataProvider.linuxSystemMetrics()
-        #expect(_metrics != nil)
-        let metrics = _metrics!
+        let metrics = try #require(SystemMetricsMonitorDataProvider.linuxSystemMetrics())
         #expect(metrics.virtualMemoryBytes != 0)
         #expect(metrics.residentMemoryBytes != 0)
         #expect(metrics.startTimeSeconds != 0)
@@ -94,12 +92,11 @@ struct LinuxDataProviderTests {
             bytes.hash(into: &hasher)
         }
 
-        let metrics = SystemMetricsMonitorDataProvider.linuxSystemMetrics()
-        #expect(metrics != nil)
+        let metrics = try #require(SystemMetricsMonitorDataProvider.linuxSystemMetrics())
 
         // We can only set expectations for the lower limit for the CPU usage time,
         // other threads executing other tests can add more CPU usage
-        #expect(metrics!.cpuSeconds > 0)
+        #expect(metrics.cpuSeconds > 0)
     }
 
     @Test("Data provider returns valid metrics via protocol")
@@ -121,9 +118,7 @@ struct LinuxDataProviderTests {
 
         let provider = SystemMetricsMonitorDataProvider(configuration: configuration)
         let data = await provider.data()
-
-        #expect(data != nil)
-        let metrics = data!
+        let metrics = try #require(data)
         #expect(metrics.virtualMemoryBytes > 0)
         #expect(metrics.residentMemoryBytes > 0)
         #expect(metrics.startTimeSeconds > 0)


### PR DESCRIPTION
Refactor force unwraps to use `try #require` in Linux data provider tests

### Motivation:

While looking through the test suites, I noticed that `LinuxDataProviderTests.swift` was still using a pattern of doing an `#expect(value != nil)` check followed by a force unwrap (`value!`). In the new Swift Testing framework, the idiomatic and safer way to handle optionals is by using `try #require()`. Force unwrapping risks crashing the entire test runner with a fatal error, whereas `#require` gracefully fails the individual test and provides a clear diagnostic message. 

### Modifications:

- Replaced all `#expect(value != nil)` assertions and subsequent force unwraps with `try #require(value)` in `LinuxDataProviderTests.swift`.
- Cleaned up the local variable assignments to be more concise.

### Result:

The Linux test suite is now safer, won't crash the test runner on failure, and the code style is consistent with the `DarwinDataProviderTests.swift` suite.

Thanks for letting me know about this during our review @brandongrubio :)
