### PR TITLE
Add process page fault metrics (minor/major) using getrusage on Linux and Darwin

### DIFF
--- a/Examples/ServiceIntegration/README.md
+++ b/Examples/ServiceIntegration/README.md
@@ -47,3 +47,5 @@ The dashboard provides four visualizations that map to the metrics collected by 
 1. Open File Descriptors (`process_open_fds`) and Max File Descriptors (`process_max_fds`)
 
 1. Thread Count (`process_thread_count`)
+
+1. Page Faults: Minor page faults rate (`process_page_faults_minor_total`) and Major page faults rate (`process_page_faults_major_total`)

--- a/Examples/ServiceIntegration/grafana/provisioning/dashboards/grafana-dashboard-service-process-metrics.json
+++ b/Examples/ServiceIntegration/grafana/provisioning/dashboards/grafana-dashboard-service-process-metrics.json
@@ -547,6 +547,118 @@
       ],
       "title": "Thread Count",
       "type": "timeseries"
+    },
+    {
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 40
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "rate(process_page_faults_minor_total[$__rate_interval])",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Minor Page Faults",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "rate(process_page_faults_major_total[$__rate_interval])",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Major Page Faults",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Page Faults",
+      "type": "timeseries"
     }
   ],
   "preload": false,

--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ The monitor collects and reports the following metrics as gauges:
   - Metric name: `process_open_fds`
 - **Thread Count**: The number of threads in the process.
   - Metric name: `process_thread_count`
+- **Minor Page Faults**: The number of minor page faults (no disk I/O required).
+  - Metric name: `process_page_faults_minor_total`
+- **Major Page Faults**: The number of major page faults (required disk I/O).
+  - Metric name: `process_page_faults_major_total`
 
 ## Renaming metric labels
 

--- a/Sources/SystemMetrics/Docs.docc/GettingStarted.md
+++ b/Sources/SystemMetrics/Docs.docc/GettingStarted.md
@@ -93,6 +93,8 @@ let labelMapping: [String: String] = [
     "process_max_fds": "my_app_max_fds",
     "process_open_fds": "my_app_open_fds",
     "process_thread_count": "my_app_threads",
+    "process_page_faults_minor_total": "my_app_minor_page_faults",
+    "process_page_faults_major_total": "my_app_major_page_faults",
 ]
 
 let mappingFactory = MetricsSystem.factory.withLabelAndDimensionsMapping { label, dimensions in

--- a/Sources/SystemMetrics/Docs.docc/index.md
+++ b/Sources/SystemMetrics/Docs.docc/index.md
@@ -72,6 +72,10 @@ The monitor collects the following metrics:
   - Metric name: `process_open_fds`
 - **Thread Count**: The number of threads in the process.
   - Metric name: `process_thread_count`
+- **Minor Page Faults**: The number of minor page faults (no disk I/O required).
+  - Metric name: `process_page_faults_minor_total`
+- **Major Page Faults**: The number of major page faults (required disk I/O).
+  - Metric name: `process_page_faults_major_total`
 
 > Note: New metrics can be added in minor and patch versions.
 

--- a/Sources/SystemMetrics/SystemMetricsMonitor+Darwin.swift
+++ b/Sources/SystemMetrics/SystemMetricsMonitor+Darwin.swift
@@ -63,6 +63,12 @@ extension SystemMetricsMonitorDataProvider: SystemMetricsProvider {
             return cpuTimeNanoseconds / Double(NSEC_PER_SEC)
         }()
 
+        // Page faults from getrusage(RUSAGE_SELF)
+        var usage = rusage()
+        guard getrusage(RUSAGE_SELF, &usage) == 0 else { return nil }
+        let minorPageFaults = Int(usage.ru_minflt)
+        let majorPageFaults = Int(usage.ru_majflt)
+
         return .init(
             virtualMemoryBytes: virtualMemoryBytes,
             residentMemoryBytes: residentMemoryBytes,
@@ -71,7 +77,9 @@ extension SystemMetricsMonitorDataProvider: SystemMetricsProvider {
             cpuSeconds: cpuTimeSeconds,
             maxFileDescriptors: fileCounts.maximum,
             openFileDescriptors: fileCounts.open,
-            threadCount: threadCount
+            threadCount: threadCount,
+            minorPageFaults: minorPageFaults,
+            majorPageFaults: majorPageFaults
         )
     }
 

--- a/Sources/SystemMetrics/SystemMetricsMonitor+Linux.swift
+++ b/Sources/SystemMetrics/SystemMetricsMonitor+Linux.swift
@@ -137,7 +137,7 @@ extension SystemMetricsMonitorDataProvider: SystemMetricsProvider {
     /// - `sysconf(_SC_CLK_TCK)` - System clock ticks per second for time conversion
     /// - `sysconf(_SC_PAGESIZE)` - System page size for memory conversion
     /// - `/proc/self/stat` - Process memory usage and start time
-    /// - `getrusage(RUSAGE_SELF)` - CPU time
+    /// - `getrusage(RUSAGE_SELF)` - CPU time and page fault counts
     /// - `getrlimit(RLIMIT_NOFILE)` - Maximum file descriptors limit
     /// - `/proc/self/fd/` directory enumeration - Count of open file descriptors
     ///
@@ -252,6 +252,8 @@ extension SystemMetricsMonitorDataProvider: SystemMetricsProvider {
         let cpuSecondsUser: Double = Double(_rusage.ru_utime.tv_sec) + Double(_rusage.ru_utime.tv_usec) / 1_000_000.0
         let cpuSecondsSystem: Double = Double(_rusage.ru_stime.tv_sec) + Double(_rusage.ru_stime.tv_usec) / 1_000_000.0
         let cpuSecondsTotal: Double = cpuSecondsUser + cpuSecondsSystem
+        let minorPageFaults = Int(_rusage.ru_minflt)
+        let majorPageFaults = Int(_rusage.ru_majflt)
 
         guard let systemStartTimeInSecondsSinceEpoch = Self.systemStartTimeInSecondsSinceEpoch else {
             return nil
@@ -304,7 +306,9 @@ extension SystemMetricsMonitorDataProvider: SystemMetricsProvider {
             // Subtract 1 to exclude the file descriptor opened by opendir()
             // itself, which appears in /proc/self/fd during enumeration.
             openFileDescriptors: max(openFileDescriptors - 1, 0),
-            threadCount: threadCount
+            threadCount: threadCount,
+            minorPageFaults: minorPageFaults,
+            majorPageFaults: majorPageFaults
         )
     }
 }

--- a/Sources/SystemMetrics/SystemMetricsMonitor.swift
+++ b/Sources/SystemMetrics/SystemMetricsMonitor.swift
@@ -58,6 +58,8 @@ public struct SystemMetricsMonitor: Service {
     let maxFileDescriptorsGauge: Gauge
     let openFileDescriptorsGauge: Gauge
     let threadCountGauge: Gauge
+    let minorPageFaultsGauge: Gauge
+    let majorPageFaultsGauge: Gauge
 
     /// Create a new monitor for system metrics.
     ///
@@ -111,6 +113,16 @@ public struct SystemMetricsMonitor: Service {
         )
         self.threadCountGauge = Gauge(
             label: configuration.labels.label(for: \.threadCount),
+            dimensions: configuration.dimensions,
+            factory: effectiveMetricsFactory
+        )
+        self.minorPageFaultsGauge = Gauge(
+            label: configuration.labels.label(for: \.minorPageFaults),
+            dimensions: configuration.dimensions,
+            factory: effectiveMetricsFactory
+        )
+        self.majorPageFaultsGauge = Gauge(
+            label: configuration.labels.label(for: \.majorPageFaults),
             dimensions: configuration.dimensions,
             factory: effectiveMetricsFactory
         )
@@ -210,6 +222,12 @@ public struct SystemMetricsMonitor: Service {
                 self.configuration.labels.threadCount.description: Logger.MetadataValue(
                     "\(metrics.threadCount)"
                 ),
+                self.configuration.labels.minorPageFaults.description: Logger.MetadataValue(
+                    "\(metrics.minorPageFaults)"
+                ),
+                self.configuration.labels.majorPageFaults.description: Logger.MetadataValue(
+                    "\(metrics.majorPageFaults)"
+                ),
             ]
         )
         self.virtualMemoryBytesGauge.record(metrics.virtualMemoryBytes)
@@ -219,6 +237,8 @@ public struct SystemMetricsMonitor: Service {
         self.maxFileDescriptorsGauge.record(metrics.maxFileDescriptors)
         self.openFileDescriptorsGauge.record(metrics.openFileDescriptors)
         self.threadCountGauge.record(metrics.threadCount)
+        self.minorPageFaultsGauge.record(metrics.minorPageFaults)
+        self.majorPageFaultsGauge.record(metrics.majorPageFaults)
     }
 
     /// Start the monitoring loop, collecting and reporting metrics at the configured interval.
@@ -280,6 +300,10 @@ extension SystemMetricsMonitor {
         package var openFileDescriptors: Int
         /// Number of threads in the process.
         package var threadCount: Int
+        /// Number of minor page faults (no disk I/O required).
+        package var minorPageFaults: Int
+        /// Number of major page faults (required disk I/O).
+        package var majorPageFaults: Int
 
         /// Create a new instance of metrics data.
         ///
@@ -291,6 +315,8 @@ extension SystemMetricsMonitor {
         ///     - maxFileDescriptors: Maximum number of open file descriptors.
         ///     - openFileDescriptors: Number of open file descriptors.
         ///     - threadCount: Number of threads in the process.
+        ///     - minorPageFaults: Number of minor page faults.
+        ///     - majorPageFaults: Number of major page faults.
         package init(
             virtualMemoryBytes: Int,
             residentMemoryBytes: Int,
@@ -298,7 +324,9 @@ extension SystemMetricsMonitor {
             cpuSeconds: Double,
             maxFileDescriptors: Int,
             openFileDescriptors: Int,
-            threadCount: Int
+            threadCount: Int,
+            minorPageFaults: Int,
+            majorPageFaults: Int
         ) {
             self.virtualMemoryBytes = virtualMemoryBytes
             self.residentMemoryBytes = residentMemoryBytes
@@ -307,6 +335,8 @@ extension SystemMetricsMonitor {
             self.maxFileDescriptors = maxFileDescriptors
             self.openFileDescriptors = openFileDescriptors
             self.threadCount = threadCount
+            self.minorPageFaults = minorPageFaults
+            self.majorPageFaults = majorPageFaults
         }
     }
 }

--- a/Sources/SystemMetrics/SystemMetricsMonitorConfiguration.swift
+++ b/Sources/SystemMetrics/SystemMetricsMonitorConfiguration.swift
@@ -83,6 +83,10 @@ extension SystemMetricsMonitor.Configuration {
         package var openFileDescriptors: String = "open_fds"
         /// Label for number of threads.
         package var threadCount: String = "thread_count"
+        /// Label for minor page faults.
+        package var minorPageFaults: String = "page_faults_minor_total"
+        /// Label for major page faults.
+        package var majorPageFaults: String = "page_faults_major_total"
 
         /// Construct a label for a metric by concatenating the prefix with the corresponding label.
         ///
@@ -108,6 +112,8 @@ extension SystemMetricsMonitor.Configuration {
         ///     - maxFileDescriptors: Label for maximum number of open file descriptors.
         ///     - openFileDescriptors: Label for number of open file descriptors.
         ///     - threadCount: Label for number of threads.
+        ///     - minorPageFaults: Label for minor page faults.
+        ///     - majorPageFaults: Label for major page faults.
         package init(
             prefix: String,
             virtualMemoryBytes: String,
@@ -116,7 +122,9 @@ extension SystemMetricsMonitor.Configuration {
             cpuSecondsTotal: String,
             maxFileDescriptors: String,
             openFileDescriptors: String,
-            threadCount: String
+            threadCount: String,
+            minorPageFaults: String = "page_faults_minor_total",
+            majorPageFaults: String = "page_faults_major_total"
         ) {
             self.prefix = prefix
             self.virtualMemoryBytes = virtualMemoryBytes
@@ -126,6 +134,8 @@ extension SystemMetricsMonitor.Configuration {
             self.maxFileDescriptors = maxFileDescriptors
             self.openFileDescriptors = openFileDescriptors
             self.threadCount = threadCount
+            self.minorPageFaults = minorPageFaults
+            self.majorPageFaults = majorPageFaults
         }
     }
 }

--- a/Sources/SystemMetrics/SystemMetricsMonitorConfiguration.swift
+++ b/Sources/SystemMetrics/SystemMetricsMonitorConfiguration.swift
@@ -123,8 +123,8 @@ extension SystemMetricsMonitor.Configuration {
             maxFileDescriptors: String,
             openFileDescriptors: String,
             threadCount: String,
-            minorPageFaults: String = "page_faults_minor_total",
-            majorPageFaults: String = "page_faults_major_total"
+            minorPageFaults: String,
+            majorPageFaults: String
         ) {
             self.prefix = prefix
             self.virtualMemoryBytes = virtualMemoryBytes

--- a/Tests/SystemMetricsTests/DarwinDataProviderTests.swift
+++ b/Tests/SystemMetricsTests/DarwinDataProviderTests.swift
@@ -37,6 +37,8 @@ struct DarwinDataProviderTests {
         #expect(metrics.maxFileDescriptors != 0)
         #expect(metrics.openFileDescriptors != 0)
         #expect(metrics.threadCount != 0)
+        #expect(metrics.minorPageFaults >= 0)
+        #expect(metrics.majorPageFaults >= 0)
     }
 
     @Test("Resident memory size reflects allocations")
@@ -152,6 +154,28 @@ struct DarwinDataProviderTests {
         #expect(maxFDs == Int(limits.rlim_cur))
     }
 
+    @Test("Page fault counts match getrusage cross-check")
+    func pageFaultsMatchAlternative() throws {
+        // Trigger some page faults by allocating and touching memory
+        let allocationSize = 1000 * pageSize
+        var address = try #require(vmAlloc(allocationSize))
+        memset(UnsafeMutableRawPointer(bitPattern: address), 0xB3, Int(allocationSize))
+        vmFree(&address, size: allocationSize)
+
+        let metrics = try readMetrics()
+
+        var usage = rusage()
+        getrusage(RUSAGE_SELF, &usage)
+
+        // The metrics snapshot and the getrusage call happen at slightly
+        // different times, so allow a small tolerance.
+        let minorDifference = abs(metrics.minorPageFaults - Int(usage.ru_minflt))
+        #expect(minorDifference <= 100)
+
+        let majorDifference = abs(metrics.majorPageFaults - Int(usage.ru_majflt))
+        #expect(majorDifference <= 10)
+    }
+
     @Test("Data provider returns valid metrics via protocol")
     func dataProviderProtocol() async throws {
         let labels = SystemMetricsMonitor.Configuration.Labels(
@@ -178,6 +202,8 @@ struct DarwinDataProviderTests {
         #expect(metrics.maxFileDescriptors > 0)
         #expect(metrics.openFileDescriptors > 0)
         #expect(metrics.threadCount > 0)
+        #expect(metrics.minorPageFaults >= 0)
+        #expect(metrics.majorPageFaults >= 0)
     }
 
     // MARK: - Helpers

--- a/Tests/SystemMetricsTests/DarwinDataProviderTests.swift
+++ b/Tests/SystemMetricsTests/DarwinDataProviderTests.swift
@@ -186,7 +186,9 @@ struct DarwinDataProviderTests {
             cpuSecondsTotal: "cpt",
             maxFileDescriptors: "mfd",
             openFileDescriptors: "ofd",
-            threadCount: "tc"
+            threadCount: "tc",
+            minorPageFaults: "page_faults_minor_total",
+            majorPageFaults: "page_faults_major_total"
         )
         let configuration = SystemMetricsMonitor.Configuration(
             pollInterval: .seconds(1),

--- a/Tests/SystemMetricsTests/LinuxDataProviderTests.swift
+++ b/Tests/SystemMetricsTests/LinuxDataProviderTests.swift
@@ -114,7 +114,9 @@ struct LinuxDataProviderTests {
             cpuSecondsTotal: "cpt",
             maxFileDescriptors: "mfd",
             openFileDescriptors: "ofd",
-            threadCount: "tc"
+            threadCount: "tc",
+            minorPageFaults: "page_faults_minor_total",
+            majorPageFaults: "page_faults_major_total"
         )
         let configuration = SystemMetricsMonitor.Configuration(
             pollInterval: .seconds(1),

--- a/Tests/SystemMetricsTests/LinuxDataProviderTests.swift
+++ b/Tests/SystemMetricsTests/LinuxDataProviderTests.swift
@@ -36,6 +36,8 @@ struct LinuxDataProviderTests {
         #expect(metrics.maxFileDescriptors != 0)
         #expect(metrics.openFileDescriptors != 0)
         #expect(metrics.threadCount != 0)
+        #expect(metrics.minorPageFaults >= 0)
+        #expect(metrics.majorPageFaults >= 0)
     }
 
     @Test("Resident memory bytes reflects actual allocations")
@@ -129,6 +131,8 @@ struct LinuxDataProviderTests {
         #expect(metrics.startTimeSeconds > 0)
         #expect(metrics.maxFileDescriptors > 0)
         #expect(metrics.openFileDescriptors > 0)
+        #expect(metrics.minorPageFaults >= 0)
+        #expect(metrics.majorPageFaults >= 0)
     }
 
     @Test("File descriptor counts are accurate")
@@ -159,6 +163,31 @@ struct LinuxDataProviderTests {
 
         let metrics = try #require(SystemMetricsMonitorDataProvider.linuxSystemMetrics())
         #expect(metrics.maxFileDescriptors == Int(limits.rlim_cur))
+    }
+
+    @Test("Page fault counts match getrusage cross-check")
+    func pageFaultsMatchAlternative() throws {
+        // Trigger some page faults by allocating and touching memory
+        let pageByteCount = sysconf(Int32(_SC_PAGESIZE))
+        let allocationSize = 1000 * pageByteCount
+        let bytes = UnsafeMutableRawBufferPointer.allocate(byteCount: allocationSize, alignment: 1)
+        defer { bytes.deallocate() }
+        bytes.initializeMemory(as: UInt8.self, repeating: 0xB3)
+
+        let metrics = try #require(SystemMetricsMonitorDataProvider.linuxSystemMetrics())
+
+        var usage = rusage()
+        withUnsafeMutablePointer(to: &usage) { ptr in
+            _ = getrusage(__rusage_who_t(RUSAGE_SELF.rawValue), ptr)
+        }
+
+        // The metrics snapshot and the getrusage call happen at slightly
+        // different times, so allow a small tolerance.
+        let minorDifference = abs(metrics.minorPageFaults - Int(usage.ru_minflt))
+        #expect(minorDifference <= 100)
+
+        let majorDifference = abs(metrics.majorPageFaults - Int(usage.ru_majflt))
+        #expect(majorDifference <= 10)
     }
 }
 #endif

--- a/Tests/SystemMetricsTests/SystemMetricsMonitorTests.swift
+++ b/Tests/SystemMetricsTests/SystemMetricsMonitorTests.swift
@@ -92,8 +92,8 @@ struct SystemMetricsMonitorTests {
         #expect(configuration.labels.label(for: \.maxFileDescriptors) == "pfx_mfd")
         #expect(configuration.labels.label(for: \.openFileDescriptors) == "pfx_ofd")
         #expect(configuration.labels.label(for: \.threadCount) == "pfx_tc")
-        #expect(configuration.labels.label(for: \.minorPageFaults) == "pfx_page_faults_minor_total")
-        #expect(configuration.labels.label(for: \.majorPageFaults) == "pfx_page_faults_major_total")
+        #expect(configuration.labels.label(for: \.minorPageFaults) == "pfx_mpf")
+        #expect(configuration.labels.label(for: \.majorPageFaults) == "pfx_mjf")
 
         #expect(configuration.dimensions.contains(where: { $0 == ("app", "example") }))
         #expect(configuration.dimensions.contains(where: { $0 == ("environment", "production") }))

--- a/Tests/SystemMetricsTests/SystemMetricsMonitorTests.swift
+++ b/Tests/SystemMetricsTests/SystemMetricsMonitorTests.swift
@@ -46,7 +46,9 @@ struct SystemMetricsMonitorTests {
             cpuSecondsTotal: "cpt",
             maxFileDescriptors: "mfd",
             openFileDescriptors: "ofd",
-            threadCount: "tc"
+            threadCount: "tc",
+            minorPageFaults: "page_faults_minor_total",
+            majorPageFaults: "page_faults_major_total"
         )
 
         #expect(labels.label(for: \.virtualMemoryBytes) == "pfx+vmb")
@@ -56,8 +58,8 @@ struct SystemMetricsMonitorTests {
         #expect(labels.label(for: \.maxFileDescriptors) == "pfx+mfd")
         #expect(labels.label(for: \.openFileDescriptors) == "pfx+ofd")
         #expect(labels.label(for: \.threadCount) == "pfx+tc")
-        #expect(labels.label(for: \.minorPageFaults) == "pfx+page_faults_minor_total")
-        #expect(labels.label(for: \.majorPageFaults) == "pfx+page_faults_major_total")
+        #expect(labels.label(for: \.minorPageFaults) == "pfx+mpf")
+        #expect(labels.label(for: \.majorPageFaults) == "pfx+mjf")
     }
 
     @Test("Configuration preserves all provided settings")
@@ -70,7 +72,9 @@ struct SystemMetricsMonitorTests {
             cpuSecondsTotal: "cpt",
             maxFileDescriptors: "mfd",
             openFileDescriptors: "ofd",
-            threadCount: "tc"
+            threadCount: "tc",
+            minorPageFaults: "page_faults_minor_total",
+            majorPageFaults: "page_faults_major_total"
         )
         let dimensions = [("app", "example"), ("environment", "production")]
         let configuration = SystemMetricsMonitor.Configuration(
@@ -124,7 +128,9 @@ struct SystemMetricsMonitorTests {
             cpuSecondsTotal: "cpt",
             maxFileDescriptors: "mfd",
             openFileDescriptors: "ofd",
-            threadCount: "tc"
+            threadCount: "tc",
+            minorPageFaults: "page_faults_minor_total",
+            majorPageFaults: "page_faults_major_total"
         )
 
         let configuration = SystemMetricsMonitor.Configuration(
@@ -183,7 +189,9 @@ struct SystemMetricsMonitorTests {
             cpuSecondsTotal: "cpt",
             maxFileDescriptors: "mfd",
             openFileDescriptors: "ofd",
-            threadCount: "tc"
+            threadCount: "tc",
+            minorPageFaults: "page_faults_minor_total",
+            majorPageFaults: "page_faults_major_total"
         )
 
         let configuration = SystemMetricsMonitor.Configuration(
@@ -235,7 +243,9 @@ struct SystemMetricsMonitorTests {
             cpuSecondsTotal: "cpt",
             maxFileDescriptors: "mfd",
             openFileDescriptors: "ofd",
-            threadCount: "tc"
+            threadCount: "tc",
+            minorPageFaults: "page_faults_minor_total",
+            majorPageFaults: "page_faults_major_total"
         )
 
         let dimensions = [("service", "myapp"), ("environment", "production")]
@@ -303,7 +313,9 @@ struct SystemMetricsMonitorTests {
             cpuSecondsTotal: "cpt",
             maxFileDescriptors: "mfd",
             openFileDescriptors: "ofd",
-            threadCount: "tc"
+            threadCount: "tc",
+            minorPageFaults: "page_faults_minor_total",
+            majorPageFaults: "page_faults_major_total"
         )
 
         let configuration = SystemMetricsMonitor.Configuration(
@@ -348,7 +360,9 @@ struct SystemMetricsMonitorTests {
             cpuSecondsTotal: "cpt",
             maxFileDescriptors: "mfd",
             openFileDescriptors: "ofd",
-            threadCount: "tc"
+            threadCount: "tc",
+            minorPageFaults: "page_faults_minor_total",
+            majorPageFaults: "page_faults_major_total"
         )
 
         let configuration = SystemMetricsMonitor.Configuration(
@@ -488,7 +502,9 @@ struct SystemMetricsInitializationTests {
             cpuSecondsTotal: "cpt",
             maxFileDescriptors: "mfd",
             openFileDescriptors: "ofd",
-            threadCount: "tc"
+            threadCount: "tc",
+            minorPageFaults: "page_faults_minor_total",
+            majorPageFaults: "page_faults_major_total"
         )
 
         let configuration = SystemMetricsMonitor.Configuration(
@@ -523,7 +539,9 @@ struct SystemMetricsInitializationTests {
             cpuSecondsTotal: "cpt",
             maxFileDescriptors: "mfd",
             openFileDescriptors: "ofd",
-            threadCount: "tc"
+            threadCount: "tc",
+            minorPageFaults: "page_faults_minor_total",
+            majorPageFaults: "page_faults_major_total"
         )
 
         let configuration = SystemMetricsMonitor.Configuration(

--- a/Tests/SystemMetricsTests/SystemMetricsMonitorTests.swift
+++ b/Tests/SystemMetricsTests/SystemMetricsMonitorTests.swift
@@ -56,6 +56,8 @@ struct SystemMetricsMonitorTests {
         #expect(labels.label(for: \.maxFileDescriptors) == "pfx+mfd")
         #expect(labels.label(for: \.openFileDescriptors) == "pfx+ofd")
         #expect(labels.label(for: \.threadCount) == "pfx+tc")
+        #expect(labels.label(for: \.minorPageFaults) == "pfx+page_faults_minor_total")
+        #expect(labels.label(for: \.majorPageFaults) == "pfx+page_faults_major_total")
     }
 
     @Test("Configuration preserves all provided settings")
@@ -86,6 +88,8 @@ struct SystemMetricsMonitorTests {
         #expect(configuration.labels.label(for: \.maxFileDescriptors) == "pfx_mfd")
         #expect(configuration.labels.label(for: \.openFileDescriptors) == "pfx_ofd")
         #expect(configuration.labels.label(for: \.threadCount) == "pfx_tc")
+        #expect(configuration.labels.label(for: \.minorPageFaults) == "pfx_page_faults_minor_total")
+        #expect(configuration.labels.label(for: \.majorPageFaults) == "pfx_page_faults_major_total")
 
         #expect(configuration.dimensions.contains(where: { $0 == ("app", "example") }))
         #expect(configuration.dimensions.contains(where: { $0 == ("environment", "production") }))
@@ -104,7 +108,9 @@ struct SystemMetricsMonitorTests {
             cpuSeconds: 4000,
             maxFileDescriptors: 5000,
             openFileDescriptors: 6000,
-            threadCount: 7000
+            threadCount: 7000,
+            minorPageFaults: 8000,
+            majorPageFaults: 9000
         )
 
         let provider = MockMetricsProvider(mockData: mockData)
@@ -155,6 +161,12 @@ struct SystemMetricsMonitorTests {
 
         let tcGauge = try testMetrics.expectGauge("test_tc")
         #expect(tcGauge.lastValue == 7000)
+
+        let minPfGauge = try testMetrics.expectGauge("test_page_faults_minor_total")
+        #expect(minPfGauge.lastValue == 8000)
+
+        let majPfGauge = try testMetrics.expectGauge("test_page_faults_major_total")
+        #expect(majPfGauge.lastValue == 9000)
     }
 
     @Test("Monitor with nil provider does not report metrics")
@@ -187,7 +199,7 @@ struct SystemMetricsMonitorTests {
         )
 
         // Recorders are created along with the Monitor
-        #expect(testMetrics.recorders.count == 7)
+        #expect(testMetrics.recorders.count == 9)
 
         await monitor.updateMetrics()
 
@@ -207,7 +219,9 @@ struct SystemMetricsMonitorTests {
             cpuSeconds: 4000,
             maxFileDescriptors: 5000,
             openFileDescriptors: 6000,
-            threadCount: 7000
+            threadCount: 7000,
+            minorPageFaults: 8000,
+            majorPageFaults: 9000
         )
 
         let provider = MockMetricsProvider(mockData: mockData)
@@ -273,7 +287,9 @@ struct SystemMetricsMonitorTests {
             cpuSeconds: 4000,
             maxFileDescriptors: 5000,
             openFileDescriptors: 6000,
-            threadCount: 7000
+            threadCount: 7000,
+            minorPageFaults: 8000,
+            majorPageFaults: 9000
         )
 
         let provider = CallCountingProvider(mockData: mockData)
@@ -366,7 +382,9 @@ struct SystemMetricsMonitorTests {
             cpuSeconds: 4000,
             maxFileDescriptors: 5000,
             openFileDescriptors: 6000,
-            threadCount: 7000
+            threadCount: 7000,
+            minorPageFaults: 8000,
+            majorPageFaults: 9000
         )
 
         let provider = MockMetricsProvider(mockData: mockData)
@@ -383,6 +401,8 @@ struct SystemMetricsMonitorTests {
             "process_max_fds": "app_max_fds",
             "process_open_fds": "app_open_fds",
             "process_thread_count": "app_threads",
+            "process_page_faults_minor_total": "app_minor_pf",
+            "process_page_faults_major_total": "app_major_pf",
         ]
 
         let mappingFactory = testMetrics.withLabelAndDimensionsMapping { label, dimensions in
@@ -422,8 +442,14 @@ struct SystemMetricsMonitorTests {
         let tcGauge = try testMetrics.expectGauge("app_threads")
         #expect(tcGauge.lastValue == 7000)
 
-        // Verify that exactly 7 gauges were created — no more, no fewer.
-        #expect(testMetrics.recorders.count == 7)
+        let minPfGauge = try testMetrics.expectGauge("app_minor_pf")
+        #expect(minPfGauge.lastValue == 8000)
+
+        let majPfGauge = try testMetrics.expectGauge("app_major_pf")
+        #expect(majPfGauge.lastValue == 9000)
+
+        // Verify that exactly 9 gauges were created — no more, no fewer.
+        #expect(testMetrics.recorders.count == 9)
     }
 }
 
@@ -447,7 +473,9 @@ struct SystemMetricsInitializationTests {
             cpuSeconds: 4000,
             maxFileDescriptors: 5000,
             openFileDescriptors: 6000,
-            threadCount: 7000
+            threadCount: 7000,
+            minorPageFaults: 8000,
+            majorPageFaults: 9000
         )
 
         let provider = MockMetricsProvider(mockData: mockData)

--- a/Tests/SystemMetricsTests/SystemMetricsMonitorTests.swift
+++ b/Tests/SystemMetricsTests/SystemMetricsMonitorTests.swift
@@ -47,8 +47,8 @@ struct SystemMetricsMonitorTests {
             maxFileDescriptors: "mfd",
             openFileDescriptors: "ofd",
             threadCount: "tc",
-            minorPageFaults: "page_faults_minor_total",
-            majorPageFaults: "page_faults_major_total"
+            minorPageFaults: "mpf",
+            majorPageFaults: "mjf"
         )
 
         #expect(labels.label(for: \.virtualMemoryBytes) == "pfx+vmb")
@@ -73,8 +73,8 @@ struct SystemMetricsMonitorTests {
             maxFileDescriptors: "mfd",
             openFileDescriptors: "ofd",
             threadCount: "tc",
-            minorPageFaults: "page_faults_minor_total",
-            majorPageFaults: "page_faults_major_total"
+            minorPageFaults: "mpf",
+            majorPageFaults: "mjf"
         )
         let dimensions = [("app", "example"), ("environment", "production")]
         let configuration = SystemMetricsMonitor.Configuration(


### PR DESCRIPTION
Add process page fault metrics (minor/major) using getrusage on Linux and Darwin

### Motivation:

Identifying memory pressure and unexpected latency caused by disk I/O is critical for performance monitoring. Major page faults (which require disk I/O) are a common cause of unexpected latency in applications. Adding minor and major page fault metrics allows developers to monitor these events, providing better visibility into memory access patterns and application performance.

### Modifications:

- Updated `SystemMetricsMonitor+Linux.swift` to extract `ru_minflt` (minor faults) and `ru_majflt` (major faults) from the existing `getrusage(RUSAGE_SELF)` call.
- Updated `SystemMetricsMonitor+Darwin.swift` to include a new `getrusage(RUSAGE_SELF)` call to extract `ru_minflt` and `ru_majflt`.
- Added `minorPageFaults` and `majorPageFaults` fields to the `SystemMetricsMonitor.Data` structure.
- Created `process_page_faults_minor_total` and `process_page_faults_major_total` as default labels in `SystemMetricsMonitorConfiguration`.
- Updated test suites across both platforms to validate the new metrics with dedicated cross-check tests.

### Result:

The system metrics monitor now automatically collects and exports two new gauges (`process_page_faults_minor_total` and `process_page_faults_major_total`), providing immediate visibility into process-level memory page faults without requiring any configuration changes for existing users.

Thanks @Renish-patel for helping and guidance