### PR TITLE
Add block I/O operations metrics using getrusage

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ The monitor collects and reports the following metrics as gauges:
   - Metric name: `process_page_faults_minor_total`
 - **Major Page Faults**: The number of major page faults (required disk I/O).
   - Metric name: `process_page_faults_major_total`
+- **Block Input Operations**: The number of block input operations (disk reads).
+  - Metric name: `process_block_input_operations_total`
+- **Block Output Operations**: The number of block output operations (disk writes).
+  - Metric name: `process_block_output_operations_total`
 
 ## Renaming metric labels
 

--- a/Sources/SystemMetrics/Docs.docc/index.md
+++ b/Sources/SystemMetrics/Docs.docc/index.md
@@ -76,6 +76,10 @@ The monitor collects the following metrics:
   - Metric name: `process_page_faults_minor_total`
 - **Major Page Faults**: The number of major page faults (required disk I/O).
   - Metric name: `process_page_faults_major_total`
+- **Block Input Operations**: The number of block input operations (disk reads).
+  - Metric name: `process_block_input_operations_total`
+- **Block Output Operations**: The number of block output operations (disk writes).
+  - Metric name: `process_block_output_operations_total`
 
 > Note: New metrics can be added in minor and patch versions.
 

--- a/Sources/SystemMetrics/SystemMetricsMonitor+Darwin.swift
+++ b/Sources/SystemMetrics/SystemMetricsMonitor+Darwin.swift
@@ -68,6 +68,8 @@ extension SystemMetricsMonitorDataProvider: SystemMetricsProvider {
         guard getrusage(RUSAGE_SELF, &usage) == 0 else { return nil }
         let minorPageFaults = Int(usage.ru_minflt)
         let majorPageFaults = Int(usage.ru_majflt)
+        let blockInputOperations = Int(usage.ru_inblock)
+        let blockOutputOperations = Int(usage.ru_oublock)
 
         return .init(
             virtualMemoryBytes: virtualMemoryBytes,
@@ -79,7 +81,9 @@ extension SystemMetricsMonitorDataProvider: SystemMetricsProvider {
             openFileDescriptors: fileCounts.open,
             threadCount: threadCount,
             minorPageFaults: minorPageFaults,
-            majorPageFaults: majorPageFaults
+            majorPageFaults: majorPageFaults,
+            blockInputOperations: blockInputOperations,
+            blockOutputOperations: blockOutputOperations
         )
     }
 

--- a/Sources/SystemMetrics/SystemMetricsMonitor+Linux.swift
+++ b/Sources/SystemMetrics/SystemMetricsMonitor+Linux.swift
@@ -250,6 +250,8 @@ extension SystemMetricsMonitorDataProvider: SystemMetricsProvider {
         let cpuSecondsTotal: Double = cpuSecondsUser + cpuSecondsSystem
         let minorPageFaults = Int(_rusage.ru_minflt)
         let majorPageFaults = Int(_rusage.ru_majflt)
+        let blockInputOperations = Int(_rusage.ru_inblock)
+        let blockOutputOperations = Int(_rusage.ru_oublock)
 
         guard let systemStartTimeInSecondsSinceEpoch = Self.systemStartTimeInSecondsSinceEpoch else {
             return nil
@@ -304,7 +306,9 @@ extension SystemMetricsMonitorDataProvider: SystemMetricsProvider {
             openFileDescriptors: max(openFileDescriptors - 1, 0),
             threadCount: threadCount,
             minorPageFaults: minorPageFaults,
-            majorPageFaults: majorPageFaults
+            majorPageFaults: majorPageFaults,
+            blockInputOperations: blockInputOperations,
+            blockOutputOperations: blockOutputOperations
         )
     }
 }

--- a/Sources/SystemMetrics/SystemMetricsMonitor.swift
+++ b/Sources/SystemMetrics/SystemMetricsMonitor.swift
@@ -60,6 +60,8 @@ public struct SystemMetricsMonitor: Service {
     let threadCountGauge: Gauge
     let minorPageFaultsGauge: Gauge
     let majorPageFaultsGauge: Gauge
+    let blockInputOperationsGauge: Gauge
+    let blockOutputOperationsGauge: Gauge
 
     /// Create a new monitor for system metrics.
     ///
@@ -123,6 +125,16 @@ public struct SystemMetricsMonitor: Service {
         )
         self.majorPageFaultsGauge = Gauge(
             label: configuration.labels.label(for: \.majorPageFaults),
+            dimensions: configuration.dimensions,
+            factory: effectiveMetricsFactory
+        )
+        self.blockInputOperationsGauge = Gauge(
+            label: configuration.labels.label(for: \.blockInputOperations),
+            dimensions: configuration.dimensions,
+            factory: effectiveMetricsFactory
+        )
+        self.blockOutputOperationsGauge = Gauge(
+            label: configuration.labels.label(for: \.blockOutputOperations),
             dimensions: configuration.dimensions,
             factory: effectiveMetricsFactory
         )
@@ -228,6 +240,12 @@ public struct SystemMetricsMonitor: Service {
                 self.configuration.labels.majorPageFaults.description: Logger.MetadataValue(
                     "\(metrics.majorPageFaults)"
                 ),
+                self.configuration.labels.blockInputOperations.description: Logger.MetadataValue(
+                    "\(metrics.blockInputOperations)"
+                ),
+                self.configuration.labels.blockOutputOperations.description: Logger.MetadataValue(
+                    "\(metrics.blockOutputOperations)"
+                ),
             ]
         )
         self.virtualMemoryBytesGauge.record(metrics.virtualMemoryBytes)
@@ -239,6 +257,8 @@ public struct SystemMetricsMonitor: Service {
         self.threadCountGauge.record(metrics.threadCount)
         self.minorPageFaultsGauge.record(metrics.minorPageFaults)
         self.majorPageFaultsGauge.record(metrics.majorPageFaults)
+        self.blockInputOperationsGauge.record(metrics.blockInputOperations)
+        self.blockOutputOperationsGauge.record(metrics.blockOutputOperations)
     }
 
     /// Start the monitoring loop, collecting and reporting metrics at the configured interval.
@@ -304,6 +324,10 @@ extension SystemMetricsMonitor {
         package var minorPageFaults: Int
         /// Number of major page faults (required disk I/O).
         package var majorPageFaults: Int
+        /// Number of block input operations (disk reads).
+        package var blockInputOperations: Int
+        /// Number of block output operations (disk writes).
+        package var blockOutputOperations: Int
 
         /// Create a new instance of metrics data.
         ///
@@ -317,6 +341,8 @@ extension SystemMetricsMonitor {
         ///     - threadCount: Number of threads in the process.
         ///     - minorPageFaults: Number of minor page faults.
         ///     - majorPageFaults: Number of major page faults.
+        ///     - blockInputOperations: Number of block input operations.
+        ///     - blockOutputOperations: Number of block output operations.
         package init(
             virtualMemoryBytes: Int,
             residentMemoryBytes: Int,
@@ -326,7 +352,9 @@ extension SystemMetricsMonitor {
             openFileDescriptors: Int,
             threadCount: Int,
             minorPageFaults: Int,
-            majorPageFaults: Int
+            majorPageFaults: Int,
+            blockInputOperations: Int,
+            blockOutputOperations: Int
         ) {
             self.virtualMemoryBytes = virtualMemoryBytes
             self.residentMemoryBytes = residentMemoryBytes
@@ -337,6 +365,8 @@ extension SystemMetricsMonitor {
             self.threadCount = threadCount
             self.minorPageFaults = minorPageFaults
             self.majorPageFaults = majorPageFaults
+            self.blockInputOperations = blockInputOperations
+            self.blockOutputOperations = blockOutputOperations
         }
     }
 }

--- a/Sources/SystemMetrics/SystemMetricsMonitorConfiguration.swift
+++ b/Sources/SystemMetrics/SystemMetricsMonitorConfiguration.swift
@@ -87,6 +87,10 @@ extension SystemMetricsMonitor.Configuration {
         package var minorPageFaults: String = "page_faults_minor_total"
         /// Label for major page faults.
         package var majorPageFaults: String = "page_faults_major_total"
+        /// Label for block input operations.
+        package var blockInputOperations: String = "block_input_operations_total"
+        /// Label for block output operations.
+        package var blockOutputOperations: String = "block_output_operations_total"
 
         /// Construct a label for a metric by concatenating the prefix with the corresponding label.
         ///
@@ -114,6 +118,8 @@ extension SystemMetricsMonitor.Configuration {
         ///     - threadCount: Label for number of threads.
         ///     - minorPageFaults: Label for minor page faults.
         ///     - majorPageFaults: Label for major page faults.
+        ///     - blockInputOperations: Label for block input operations.
+        ///     - blockOutputOperations: Label for block output operations.
         package init(
             prefix: String,
             virtualMemoryBytes: String,
@@ -124,7 +130,9 @@ extension SystemMetricsMonitor.Configuration {
             openFileDescriptors: String,
             threadCount: String,
             minorPageFaults: String,
-            majorPageFaults: String
+            majorPageFaults: String,
+            blockInputOperations: String,
+            blockOutputOperations: String
         ) {
             self.prefix = prefix
             self.virtualMemoryBytes = virtualMemoryBytes
@@ -136,6 +144,8 @@ extension SystemMetricsMonitor.Configuration {
             self.threadCount = threadCount
             self.minorPageFaults = minorPageFaults
             self.majorPageFaults = majorPageFaults
+            self.blockInputOperations = blockInputOperations
+            self.blockOutputOperations = blockOutputOperations
         }
     }
 }

--- a/Tests/SystemMetricsTests/DarwinDataProviderTests.swift
+++ b/Tests/SystemMetricsTests/DarwinDataProviderTests.swift
@@ -39,6 +39,8 @@ struct DarwinDataProviderTests {
         #expect(metrics.threadCount != 0)
         #expect(metrics.minorPageFaults >= 0)
         #expect(metrics.majorPageFaults >= 0)
+        #expect(metrics.blockInputOperations >= 0)
+        #expect(metrics.blockOutputOperations >= 0)
     }
 
     @Test("Resident memory size reflects allocations")
@@ -188,7 +190,9 @@ struct DarwinDataProviderTests {
             openFileDescriptors: "ofd",
             threadCount: "tc",
             minorPageFaults: "page_faults_minor_total",
-            majorPageFaults: "page_faults_major_total"
+            majorPageFaults: "page_faults_major_total",
+            blockInputOperations: "block_input_ops",
+            blockOutputOperations: "block_output_ops"
         )
         let configuration = SystemMetricsMonitor.Configuration(
             pollInterval: .seconds(1),
@@ -206,6 +210,8 @@ struct DarwinDataProviderTests {
         #expect(metrics.threadCount > 0)
         #expect(metrics.minorPageFaults >= 0)
         #expect(metrics.majorPageFaults >= 0)
+        #expect(metrics.blockInputOperations >= 0)
+        #expect(metrics.blockOutputOperations >= 0)
     }
 
     // MARK: - Helpers

--- a/Tests/SystemMetricsTests/LinuxDataProviderTests.swift
+++ b/Tests/SystemMetricsTests/LinuxDataProviderTests.swift
@@ -36,6 +36,8 @@ struct LinuxDataProviderTests {
         #expect(metrics.threadCount != 0)
         #expect(metrics.minorPageFaults >= 0)
         #expect(metrics.majorPageFaults >= 0)
+        #expect(metrics.blockInputOperations >= 0)
+        #expect(metrics.blockOutputOperations >= 0)
     }
 
     @Test("Resident memory bytes reflects actual allocations")
@@ -113,7 +115,9 @@ struct LinuxDataProviderTests {
             openFileDescriptors: "ofd",
             threadCount: "tc",
             minorPageFaults: "page_faults_minor_total",
-            majorPageFaults: "page_faults_major_total"
+            majorPageFaults: "page_faults_major_total",
+            blockInputOperations: "block_input_ops",
+            blockOutputOperations: "block_output_ops"
         )
         let configuration = SystemMetricsMonitor.Configuration(
             pollInterval: .seconds(1),
@@ -130,6 +134,8 @@ struct LinuxDataProviderTests {
         #expect(metrics.openFileDescriptors > 0)
         #expect(metrics.minorPageFaults >= 0)
         #expect(metrics.majorPageFaults >= 0)
+        #expect(metrics.blockInputOperations >= 0)
+        #expect(metrics.blockOutputOperations >= 0)
     }
 
     @Test("File descriptor counts are accurate")

--- a/Tests/SystemMetricsTests/SystemMetricsMonitorTests.swift
+++ b/Tests/SystemMetricsTests/SystemMetricsMonitorTests.swift
@@ -48,7 +48,9 @@ struct SystemMetricsMonitorTests {
             openFileDescriptors: "ofd",
             threadCount: "tc",
             minorPageFaults: "mpf",
-            majorPageFaults: "mjf"
+            majorPageFaults: "mjf",
+            blockInputOperations: "bio",
+            blockOutputOperations: "boo"
         )
 
         #expect(labels.label(for: \.virtualMemoryBytes) == "pfx+vmb")
@@ -60,6 +62,8 @@ struct SystemMetricsMonitorTests {
         #expect(labels.label(for: \.threadCount) == "pfx+tc")
         #expect(labels.label(for: \.minorPageFaults) == "pfx+mpf")
         #expect(labels.label(for: \.majorPageFaults) == "pfx+mjf")
+        #expect(labels.label(for: \.blockInputOperations) == "pfx+bio")
+        #expect(labels.label(for: \.blockOutputOperations) == "pfx+boo")
     }
 
     @Test("Configuration preserves all provided settings")
@@ -74,7 +78,9 @@ struct SystemMetricsMonitorTests {
             openFileDescriptors: "ofd",
             threadCount: "tc",
             minorPageFaults: "mpf",
-            majorPageFaults: "mjf"
+            majorPageFaults: "mjf",
+            blockInputOperations: "bio",
+            blockOutputOperations: "boo"
         )
         let dimensions = [("app", "example"), ("environment", "production")]
         let configuration = SystemMetricsMonitor.Configuration(
@@ -94,6 +100,8 @@ struct SystemMetricsMonitorTests {
         #expect(configuration.labels.label(for: \.threadCount) == "pfx_tc")
         #expect(configuration.labels.label(for: \.minorPageFaults) == "pfx_mpf")
         #expect(configuration.labels.label(for: \.majorPageFaults) == "pfx_mjf")
+        #expect(configuration.labels.label(for: \.blockInputOperations) == "pfx_bio")
+        #expect(configuration.labels.label(for: \.blockOutputOperations) == "pfx_boo")
 
         #expect(configuration.dimensions.contains(where: { $0 == ("app", "example") }))
         #expect(configuration.dimensions.contains(where: { $0 == ("environment", "production") }))
@@ -114,7 +122,9 @@ struct SystemMetricsMonitorTests {
             openFileDescriptors: 6000,
             threadCount: 7000,
             minorPageFaults: 8000,
-            majorPageFaults: 9000
+            majorPageFaults: 9000,
+            blockInputOperations: 10000,
+            blockOutputOperations: 11000
         )
 
         let provider = MockMetricsProvider(mockData: mockData)
@@ -130,7 +140,9 @@ struct SystemMetricsMonitorTests {
             openFileDescriptors: "ofd",
             threadCount: "tc",
             minorPageFaults: "page_faults_minor_total",
-            majorPageFaults: "page_faults_major_total"
+            majorPageFaults: "page_faults_major_total",
+            blockInputOperations: "block_input_ops",
+            blockOutputOperations: "block_output_ops"
         )
 
         let configuration = SystemMetricsMonitor.Configuration(
@@ -173,6 +185,12 @@ struct SystemMetricsMonitorTests {
 
         let majPfGauge = try testMetrics.expectGauge("test_page_faults_major_total")
         #expect(majPfGauge.lastValue == 9000)
+
+        let bioGauge = try testMetrics.expectGauge("test_block_input_ops")
+        #expect(bioGauge.lastValue == 10000)
+
+        let booGauge = try testMetrics.expectGauge("test_block_output_ops")
+        #expect(booGauge.lastValue == 11000)
     }
 
     @Test("Monitor with nil provider does not report metrics")
@@ -191,7 +209,9 @@ struct SystemMetricsMonitorTests {
             openFileDescriptors: "ofd",
             threadCount: "tc",
             minorPageFaults: "page_faults_minor_total",
-            majorPageFaults: "page_faults_major_total"
+            majorPageFaults: "page_faults_major_total",
+            blockInputOperations: "block_input_ops",
+            blockOutputOperations: "block_output_ops"
         )
 
         let configuration = SystemMetricsMonitor.Configuration(
@@ -207,7 +227,7 @@ struct SystemMetricsMonitorTests {
         )
 
         // Recorders are created along with the Monitor
-        #expect(testMetrics.recorders.count == 9)
+        #expect(testMetrics.recorders.count == 11)
 
         await monitor.updateMetrics()
 
@@ -229,7 +249,9 @@ struct SystemMetricsMonitorTests {
             openFileDescriptors: 6000,
             threadCount: 7000,
             minorPageFaults: 8000,
-            majorPageFaults: 9000
+            majorPageFaults: 9000,
+            blockInputOperations: 10000,
+            blockOutputOperations: 11000
         )
 
         let provider = MockMetricsProvider(mockData: mockData)
@@ -245,7 +267,9 @@ struct SystemMetricsMonitorTests {
             openFileDescriptors: "ofd",
             threadCount: "tc",
             minorPageFaults: "page_faults_minor_total",
-            majorPageFaults: "page_faults_major_total"
+            majorPageFaults: "page_faults_major_total",
+            blockInputOperations: "block_input_ops",
+            blockOutputOperations: "block_output_ops"
         )
 
         let dimensions = [("service", "myapp"), ("environment", "production")]
@@ -299,7 +323,9 @@ struct SystemMetricsMonitorTests {
             openFileDescriptors: 6000,
             threadCount: 7000,
             minorPageFaults: 8000,
-            majorPageFaults: 9000
+            majorPageFaults: 9000,
+            blockInputOperations: 10000,
+            blockOutputOperations: 11000
         )
 
         let provider = CallCountingProvider(mockData: mockData)
@@ -315,7 +341,9 @@ struct SystemMetricsMonitorTests {
             openFileDescriptors: "ofd",
             threadCount: "tc",
             minorPageFaults: "page_faults_minor_total",
-            majorPageFaults: "page_faults_major_total"
+            majorPageFaults: "page_faults_major_total",
+            blockInputOperations: "block_input_ops",
+            blockOutputOperations: "block_output_ops"
         )
 
         let configuration = SystemMetricsMonitor.Configuration(
@@ -362,7 +390,9 @@ struct SystemMetricsMonitorTests {
             openFileDescriptors: "ofd",
             threadCount: "tc",
             minorPageFaults: "page_faults_minor_total",
-            majorPageFaults: "page_faults_major_total"
+            majorPageFaults: "page_faults_major_total",
+            blockInputOperations: "block_input_ops",
+            blockOutputOperations: "block_output_ops"
         )
 
         let configuration = SystemMetricsMonitor.Configuration(
@@ -398,7 +428,9 @@ struct SystemMetricsMonitorTests {
             openFileDescriptors: 6000,
             threadCount: 7000,
             minorPageFaults: 8000,
-            majorPageFaults: 9000
+            majorPageFaults: 9000,
+            blockInputOperations: 10000,
+            blockOutputOperations: 11000
         )
 
         let provider = MockMetricsProvider(mockData: mockData)
@@ -417,6 +449,8 @@ struct SystemMetricsMonitorTests {
             "process_thread_count": "app_threads",
             "process_page_faults_minor_total": "app_minor_pf",
             "process_page_faults_major_total": "app_major_pf",
+            "process_block_input_operations_total": "app_block_in",
+            "process_block_output_operations_total": "app_block_out",
         ]
 
         let mappingFactory = testMetrics.withLabelAndDimensionsMapping { label, dimensions in
@@ -462,8 +496,14 @@ struct SystemMetricsMonitorTests {
         let majPfGauge = try testMetrics.expectGauge("app_major_pf")
         #expect(majPfGauge.lastValue == 9000)
 
-        // Verify that exactly 9 gauges were created — no more, no fewer.
-        #expect(testMetrics.recorders.count == 9)
+        let bioGauge = try testMetrics.expectGauge("app_block_in")
+        #expect(bioGauge.lastValue == 10000)
+
+        let booGauge = try testMetrics.expectGauge("app_block_out")
+        #expect(booGauge.lastValue == 11000)
+
+        // Verify that exactly 11 gauges were created — no more, no fewer.
+        #expect(testMetrics.recorders.count == 11)
     }
 }
 
@@ -489,7 +529,9 @@ struct SystemMetricsInitializationTests {
             openFileDescriptors: 6000,
             threadCount: 7000,
             minorPageFaults: 8000,
-            majorPageFaults: 9000
+            majorPageFaults: 9000,
+            blockInputOperations: 10000,
+            blockOutputOperations: 11000
         )
 
         let provider = MockMetricsProvider(mockData: mockData)
@@ -504,7 +546,9 @@ struct SystemMetricsInitializationTests {
             openFileDescriptors: "ofd",
             threadCount: "tc",
             minorPageFaults: "page_faults_minor_total",
-            majorPageFaults: "page_faults_major_total"
+            majorPageFaults: "page_faults_major_total",
+            blockInputOperations: "block_input_ops",
+            blockOutputOperations: "block_output_ops"
         )
 
         let configuration = SystemMetricsMonitor.Configuration(
@@ -541,7 +585,9 @@ struct SystemMetricsInitializationTests {
             openFileDescriptors: "ofd",
             threadCount: "tc",
             minorPageFaults: "page_faults_minor_total",
-            majorPageFaults: "page_faults_major_total"
+            majorPageFaults: "page_faults_major_total",
+            blockInputOperations: "block_input_ops",
+            blockOutputOperations: "block_output_ops"
         )
 
         let configuration = SystemMetricsMonitor.Configuration(


### PR DESCRIPTION
Add block I/O operations metrics (`ru_inblock` / `ru_oublock`) from `getrusage` to monitor system disk read/write pressure.

### Motivation:

While the library successfully tracks CPU and memory usage, it currently lacks visibility into disk I/O metrics. Monitoring disk operations is key to diagnosing I/O performance bottlenecks and understanding system read/write pressure. By extracting these metrics from `getrusage`, we can retrieve this critical data without introducing new system calls or adding overhead on Darwin and Linux.

### Modifications:

- **Sources/SystemMetrics/SystemMetricsMonitor.swift**: Added `blockInputOperationsGauge` and `blockOutputOperationsGauge` to system metrics, defined fields in the `Data` struct, and updated recording and telemetry logging logic.

- **Sources/SystemMetrics/SystemMetricsMonitorConfiguration.swift**: Added `blockInputOperations` and `blockOutputOperations` keys to the metrics configuration `Labels`.

- **Sources/SystemMetrics/SystemMetricsMonitor+Darwin.swift** & **+Linux.swift**: Updated the platform-specific data providers to extract `ru_inblock` and `ru_oublock` from the underlying `rusage` struct.

- **Tests/SystemMetricsTests/**: Updated unit tests (`SystemMetricsMonitorTests.swift`, `DarwinDataProviderTests.swift`, `LinuxDataProviderTests.swift`) to validate and assert the correct extraction of block I/O metrics.

- **README.md** & **Sources/SystemMetrics/Docs.docc/index.md**: Documented the two new metrics under the available metrics sections.

### Result:

The library now exposes two new metrics to track disk activity: `system_block_input_operations_total` and `system_block_output_operations_total`.

---

*Co-authored by @Renish-Patel <renishpatel2482001@gmail.com> for collaboration on the approach and help with the implementation.*
