### PR TITLE
docs: add Grafana CPU alert example to ServiceIntegration

### DIFF
--- a/Examples/ServiceIntegration/README.md
+++ b/Examples/ServiceIntegration/README.md
@@ -49,3 +49,22 @@ The dashboard provides four visualizations that map to the metrics collected by 
 1. Thread Count (`process_thread_count`)
 
 1. Page Faults: Minor page faults rate (`process_page_faults_minor_total`) and Major page faults rate (`process_page_faults_major_total`)
+
+## Grafana Alert Example
+
+In addition to the dashboard, this example provisions a Grafana alert rule that
+fires when process CPU usage stays above 90% for 2 minutes.
+
+The rule evaluates:
+
+```promql
+rate(process_cpu_seconds_total[5m])
+```
+
+with a threshold of `0.9` (90%, matching the dashboard's `percentunit` CPU panel).
+
+After `docker-compose up --build`, open Grafana at http://localhost:3000 and go to
+**Alerting → Alert rules**. You should see **High CPU usage** under the
+**Service Process Metrics** folder. The rule definition lives in
+[`grafana/provisioning/alerting/high-cpu-usage.yaml`](grafana/provisioning/alerting/high-cpu-usage.yaml).
+

--- a/Examples/ServiceIntegration/docker-compose.yaml
+++ b/Examples/ServiceIntegration/docker-compose.yaml
@@ -19,6 +19,7 @@ services:
     volumes:
       - ./grafana/provisioning/dashboards/service-process-metrics-dashboard.yaml:/otel-lgtm/grafana/conf/provisioning/dashboards/service-process-metrics-dashboard.yaml
       - ./grafana/provisioning/dashboards/grafana-dashboard-service-process-metrics.json:/otel-lgtm/grafana-dashboard-service-process-metrics.json
+      - ./grafana/provisioning/alerting/high-cpu-usage.yaml:/otel-lgtm/grafana/conf/provisioning/alerting/high-cpu-usage.yaml
     ports:
       - "3000:3000"
       - "4317:4317"

--- a/Examples/ServiceIntegration/grafana/provisioning/alerting/high-cpu-usage.yaml
+++ b/Examples/ServiceIntegration/grafana/provisioning/alerting/high-cpu-usage.yaml
@@ -1,0 +1,89 @@
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: process_system_metrics
+    folder: Service Process Metrics
+    interval: 1m
+    rules:
+      - uid: ssm_high_cpu_usage
+        title: High CPU usage
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              editorMode: code
+              expr: rate(process_cpu_seconds_total[5m])
+              instant: true
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+          - refId: B
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 0
+              to: 0
+            model:
+              conditions:
+                - evaluator:
+                    params: []
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - B
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: A
+              intervalMs: 1000
+              maxDataPoints: 43200
+              reducer: last
+              refId: B
+              type: reduce
+          - refId: C
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 0
+              to: 0
+            model:
+              conditions:
+                - evaluator:
+                    params:
+                      - 0.9
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - C
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: B
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: C
+              type: threshold
+        noDataState: NoData
+        execErrState: Error
+        for: 2m
+        annotations:
+          description: Process CPU usage is above 90% for the Service Integration example.
+          summary: CPU usage > 90%
+        labels:
+          severity: warning
+        isPaused: false


### PR DESCRIPTION
## Summary
- Add a provisioned Grafana alert rule for process CPU usage above 90% (`rate(process_cpu_seconds_total[5m]) > 0.9` for 2m).
- Mount the alerting provisioning file in `docker-compose.yaml`.
- Document the alert in the Service Integration README.

Fixes #114

## Test plan
- [ ] `docker-compose -f Examples/ServiceIntegration/docker-compose.yaml up --build`
- [ ] In Grafana → Alerting → Alert rules, confirm **High CPU usage** appears under **Service Process Metrics**